### PR TITLE
Inspect property before output to avoid sass choking on null values

### DIFF
--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -12,7 +12,7 @@
   @each $usecase in $o-colors-usecase-list {
     @if (($property and $name == nth($usecase, 1) and $property == nth($usecase, 3)) or (not $property and $name == nth($usecase, 1) + '-' + nth($usecase, 3))) {
       @if (length($usecase) == 4 and nth($usecase,4) == DEPRECATED) {
-        @warn "Deprecated use-case name '" + $name + "', variant '" + $property + "' used";
+        @warn "Deprecated use-case name '" + $name + "', variant '" + inspect($property) + "' used";
       }
       @return _oColorsGetPaletteColor(nth($usecase,2));
     }


### PR DESCRIPTION
See http://hugogiraudel.com/2014/01/27/casting-types-in-sass/#string. Inspect is only available in Sass 3.3; not sure if this is a problem
