### PR TITLE
Add use cases for healthchecks

### DIFF
--- a/src/scss/_use-cases.scss
+++ b/src/scss/_use-cases.scss
@@ -138,8 +138,8 @@ $o-colors-usecase-list:
     dialog-close                      white                  text,
     
     // Healthchecks
-    health-ok                         green                  background,
-    health-ok                         white                  text,
-    health-error                      red                    background,
-    health-error                      white                  text
+    status-ok                         green                  background,
+    status-ok                         white                  text,
+    status-error                      red                    background,
+    status-error                      white                  text
 ;


### PR DESCRIPTION
I've chosen green for ok and red for error.  I hope that makes sense.  I wasn't sure if I should pick more atheistically pleasing tints, so I just went with the standard ones - feel free to change that.
