### PR TITLE
Unification colors

### DIFF
--- a/src/scss/_palette.scss
+++ b/src/scss/_palette.scss
@@ -94,6 +94,7 @@ $o-colors-palette: map-merge((
 	'warm-2':                #f6e9d8,
 	'warm-3':                #cec6b9,
 	'warm-4':                #1d1d1d,
+	'warm-5':                #fdf8f2,
 
 	'cold-1':                #505050,
 	'cold-2':                #333333,
@@ -110,5 +111,8 @@ $o-colors-palette: map-merge((
 
 	'link-1':                #27757b,
 	'link-2':                #2bbbbf,
+
+	'claret-inverse':        #ff7f8a
+
 
 ), $o-colors-palette);

--- a/src/scss/_palette.scss
+++ b/src/scss/_palette.scss
@@ -112,7 +112,8 @@ $o-colors-palette: map-merge((
 	'link-1':                #27757b,
 	'link-2':                #2bbbbf,
 
-	'claret-inverse':        #ff7f8a
+	'claret-1':              #9e2f50,
+	'claret-2':              #ff7f8a
 
 
 ), $o-colors-palette);


### PR DESCRIPTION
/cc @AlbertoElias @andygnewman 

Following the example of `cold-1` and `cold-2` (which are the same as some of the grey tints) - decided to copy `claret` to `claret-1`.

Bonus is that it allows us to change that color without affecting other apps.