### PR TITLE
Add next colours

### DIFF
--- a/demos/palette.html
+++ b/demos/palette.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="o-techdocs-content">
+<html class="o-hoverable-on o-techdocs-content">
 <head>
 	<meta charset="utf-8" />
 	<meta http-equiv="X-UA-Compatible" content="IE=Edge" />

--- a/demos/sass-usage.html
+++ b/demos/sass-usage.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="o-techdocs-content">
+<html class="o-hoverable-on o-techdocs-content">
 <head>
 	<meta charset="utf-8" />
 	<meta http-equiv="X-UA-Compatible" content="IE=Edge" />

--- a/demos/src/config.json
+++ b/demos/src/config.json
@@ -2,7 +2,7 @@
 	"options": {
 		"sass": "demos/src/demo.scss",
 		"js": "demos/src/demo.js",
-		"bodyClasses": "o-techdocs-content",
+		"documentClasses": "o-techdocs-content",
 		"dependencies": ["o-techdocs@^4.0.0"]
 	},
 	"demos": [

--- a/demos/use-cases.html
+++ b/demos/use-cases.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="o-techdocs-content">
+<html class="o-hoverable-on o-techdocs-content">
 <head>
 	<meta charset="utf-8" />
 	<meta http-equiv="X-UA-Compatible" content="IE=Edge" />

--- a/src/scss/_palette.scss
+++ b/src/scss/_palette.scss
@@ -112,8 +112,10 @@ $o-colors-palette: map-merge((
 	'link-1':                #27757b,
 	'link-2':                #2bbbbf,
 
+	'teal-1':                #27757b,
+	'teal-2':                #2bbbbf,
+
 	'claret-1':              #9e2f50,
 	'claret-2':              #ff7f8a
-
 
 ), $o-colors-palette);

--- a/src/scss/_palette.scss
+++ b/src/scss/_palette.scss
@@ -100,22 +100,13 @@ $o-colors-palette: map-merge((
 	'cold-2':                #333333,
 	'cold-3':                #1d1d1d,
 
-	'red-1':                 #c00d00,
-	'red-2':                 #f99d9d,
-
 	'blue-1':                #002758,
 	'blue-2':                #eeeeee,
 
 	'purple-1':              #410057,
 	'purple-2':              #f3dee3,
 
-	'link-1':                #27757b,
-	'link-2':                #2bbbbf,
-
 	'teal-1':                #27757b,
 	'teal-2':                #2bbbbf,
-
-	'claret-1':              #9e2f50,
-	'claret-2':              #ff7f8a
 
 ), $o-colors-palette);


### PR DESCRIPTION
This is a stable base for the new Next FT designs.

See https://next.ft.com/__styleguide/design-primitives#palette for documentation.

Thanks to @pauloneillft @simonwilliamsFT @adgad and @keirog for their contributions.