### PR TITLE
Change build URLs

### DIFF
--- a/demos/src/demo.js
+++ b/demos/src/demo.js
@@ -12,7 +12,7 @@ function loadDemo(showtype) {
 
 		// Gets the module and version from the url
 		const module = location.pathname.match(/o-colors(.*?)(?=\/)/g);
-		const reqUrl = 'https://build.origami.ft.com/v2/files/';
+		const reqUrl = 'https://origami-build.ft.com/v2/files/';
 		oReq.open('GET', ((location.pathname.indexOf('/local') !== -1) ? '../..' : reqUrl + module[0]) + '/src/scss/_' + type + '.scss', true);
 
 		oReq.onload = function() {


### PR DESCRIPTION
Update demo.js with the new build URL due to migrating from Akamai to Fastly.