### PR TITLE
Update for Next

### DIFF
--- a/src/scss/_use-cases.scss
+++ b/src/scss/_use-cases.scss
@@ -25,8 +25,8 @@ $o-colors-usecases: map-merge((
 
 	page:                     (background: 'pink', text: 'grey-tint5'),
 	box:                      (background: 'pink-tint1'),
-	link:                     (text: 'blue'),
-	link-hover:               (text: 'black'),
+	link:                     (text: 'teal-1'),
+	link-hover:               (text: 'grey-tint4'),
 	link-title:               (text: 'grey-tint5'),
 	link-title-hover:         (text: 'blue'),
 	tag-link:                 (text: 'claret'),

--- a/src/scss/_use-cases.scss
+++ b/src/scss/_use-cases.scss
@@ -29,6 +29,8 @@ $o-colors-usecases: map-merge((
 	link-hover:               (text: 'black'),
 	link-title:               (text: 'grey-tint5'),
 	link-title-hover:         (text: 'blue'),
+	tag-link:                 (text: 'claret'),
+	tag-link-hover:           (text: 'grey-tint4'),
 	title:                    (text: 'black'),
 	body:                     (text: 'grey-tint5'),
 	muted:                    (text: 'pink-tint3'),


### PR DESCRIPTION
This PR does two things:

1. Next are now using claret in a lot of places, all for a type of utility text called a `tag`. This PR adds this new use-case.
2. Updates the link color from blue to teal, which is the link color next have settled on.
