### PR TITLE
Update to tag-hover color

### DIFF
--- a/src/scss/_palette.scss
+++ b/src/scss/_palette.scss
@@ -110,7 +110,8 @@ $o-colors-palette: map-merge((
 	'teal-1':                #27757b,
 	'teal-2':                #2bbbbf,
 
-	'claret-1':                #9e2f50,
+	'claret-1':              #9e2f50,
 	'claret-2':              #ff7f8a,
+	'claret-inverse':        #4f1828,
 
 ), $o-colors-palette);

--- a/src/scss/_use-cases.scss
+++ b/src/scss/_use-cases.scss
@@ -30,7 +30,7 @@ $o-colors-usecases: map-merge((
 	link-title:               (text: 'grey-tint5'),
 	link-title-hover:         (text: 'blue'),
 	tag-link:                 (text: 'claret'),
-	tag-link-hover:           (text: 'grey-tint4'),
+	tag-link-hover:           (text: 'claret-inverse'),
 	title:                    (text: 'black'),
 	body:                     (text: 'grey-tint5'),
 	muted:                    (text: 'pink-tint3'),


### PR DESCRIPTION
There are two colors for the tag at the moment. #505050 and n-ui's 'claret-inverse'
I asked Sue Vago about this and she said claret-inverse is the correct color.