### PR TITLE
Add keywords to origami.json

### DIFF
--- a/origami.json
+++ b/origami.json
@@ -2,6 +2,7 @@
 	"description": "FT brand colours: Sass variables and helpers to use and define them",
 	"origamiType": "module",
 	"origamiCategory": "primitives",
+	"keywords": "colours, themes, schemes, pink, salmon, background, palette",
 	"origamiVersion": 1,
 	"support": "https://github.com/Financial-Times/o-colors/issues",
 	"supportStatus": "active",


### PR DESCRIPTION
Allows people to find `o-colors` when searching for the correct spelling of colours.