### PR TITLE
Fix contrast of teal-1 with pink-tint-1 for small sizes

### DIFF
--- a/src/scss/_palette.scss
+++ b/src/scss/_palette.scss
@@ -107,7 +107,7 @@ $o-colors-palette: map-merge((
 	'purple-1':              #410057,
 	'purple-2':              #f3dee3,
 
-	'teal-1':                #27757b,
+	'teal-1':                #26747a,
 	'teal-2':                #2bbbbf,
 
 	'claret-1':              #9e2f50,


### PR DESCRIPTION
This commit makes a barely perceivable change to teal-1 to make it
meet AA WCAG standards when used at small font sizes:


![screen shot 2016-11-18 at 15 18 05](https://cloud.githubusercontent.com/assets/68009/20435017/555b3668-ada2-11e6-8cd8-ced7aaabe73c.png)

(left is the new color, right is the old one)
