### PR TITLE
Revert "Fix teal saturation"

### DIFF
--- a/src/scss/_palette.scss
+++ b/src/scss/_palette.scss
@@ -75,7 +75,7 @@ $o-colors-tints: (
 	),
 	'teal': (
 		hue: 185,
-		saturation: 100,
+		saturation: 90,
 		tints: (20, 30, 40, 50, 60, 70, 80, 90, 100),
 	),
 	'wheat': (


### PR DESCRIPTION
Reverts Financial-Times/o-colors#128 – this doesn't pass the contrast checks :( didn't run in the original PR because it was PRed from a fork.

Reverting for now and will fix in a separate PR.