### PR TITLE
Brand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ test/output/
 demos/local
 .DS_Store
 node_modules/
-bower_components/

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ test/output/
 demos/local
 .DS_Store
 node_modules/
+bower_components/

--- a/bower.json
+++ b/bower.json
@@ -1,8 +1,6 @@
 {
   "name": "o-colors",
-  "main": [
-    "main.scss"
-  ],
+  "main": ["main.scss"],
   "ignore": [
     "test",
     ".travis.yml"

--- a/bower.json
+++ b/bower.json
@@ -1,8 +1,13 @@
 {
-    "name": "o-colors",
-    "main": ["main.scss"],
-    "ignore": [
-    	"test",
-    	".travis.yml"
-    ]
+  "name": "o-colors",
+  "main": [
+    "main.scss"
+  ],
+  "ignore": [
+    "test",
+    ".travis.yml"
+  ],
+  "dependencies": {
+    "o-brand": "^1.0.0"
+  }
 }

--- a/bower.json
+++ b/bower.json
@@ -6,8 +6,5 @@
   "ignore": [
     "test",
     ".travis.yml"
-  ],
-  "dependencies": {
-    "o-brand": "^1.0.0"
-  }
+  ]
 }

--- a/origami.json
+++ b/origami.json
@@ -20,24 +20,28 @@
 	"demos": [
 		{
 			"name": "palette",
+			"title": "Palette",
 			"data": "demos/src/palette.json",
 			"template": "demos/src/palette.mustache",
 			"display_html": false
 		},
 		{
 			"name": "tints",
+			"title": "Tints",
 			"data": "demos/src/palette.json",
 			"template": "demos/src/tints.mustache",
 			"display_html": false
 		},
 		{
 			"name": "use-cases",
+			"title": "Use cases",
 			"template": "demos/src/use-cases.mustache",
 			"display_html": false,
 			"hidden": true
 		},
 		{
 			"name": "pa11y",
+			"title": "Pa11y",
 			"data": "demos/src/palette.json",
 			"template": "demos/src/pa11y.mustache",
 			"hidden": true,

--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -8,7 +8,7 @@
 /// @param {String} $name
 @function oColorsGetPaletteColor($name) {
 	@if (map-has-key($o-colors-palette, $name)) {
-		@if ($name == 'internal-slate'  or $name == 'internal-slate-5' or $name == 'internal-slate-15') {
+		@if ($name == 'internal-slate' or $name == 'internal-slate-5' or $name == 'internal-slate-15') {
 			@warn "This color is not officially a part of the o-colors palette. It is for experimental use, and may be removed at any time.";
 		}
 

--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -8,6 +8,10 @@
 /// @param {String} $name
 @function oColorsGetPaletteColor($name) {
 	@if (map-has-key($o-colors-palette, $name)) {
+		@if ($name == 'internal-slate'  or $name == 'internal-slate-5' or $name == 'internal-slate-15') {
+			@warn "This color is not officially a part of the o-colors palette. It is for experimental use, and may be removed at any time.";
+		}
+
 		@return map-get($o-colors-palette, $name);
 	} @else {
 		@warn "Color name '#{inspect($name)}' is not defined in the palette";

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -96,7 +96,9 @@
 				$name: "#{$color}-#{$value}";
 				$tint: null;
 
-				@if $saturation == null {
+				@if $saturation == null and $color == 'internal-slate' {
+					$tint: oColorsMix($color, $background: 'white', $percentage: $value);
+				} @else if $saturation == null {
 					$tint: oColorsMix($color, $percentage: $value);
 				} @else {
 					$tint: _oColorsHSB($hue, $saturation, $value);

--- a/src/scss/_palette.scss
+++ b/src/scss/_palette.scss
@@ -54,6 +54,8 @@ $o-colors-palette: map-merge((
 	'org-b2c':               #4e96eb,
 	'org-b2c-dark':          #3a70af,
 	'org-b2c-light':         #99c6fb,
+
+	'internal-slate':         #262a33,
 ), $o-colors-palette);
 
 $o-colors-tints: (
@@ -117,5 +119,8 @@ $o-colors-tints: (
 	'crimson': (
 		hue: 360,
 		saturation: 100,
+	),
+	'internal-slate': (
+		tints: (5, 15),
 	)
 );

--- a/src/scss/_palette.scss
+++ b/src/scss/_palette.scss
@@ -55,7 +55,7 @@ $o-colors-palette: map-merge((
 	'org-b2c-dark':          #3a70af,
 	'org-b2c-light':         #99c6fb,
 
-	'internal-slate':         #262a33,
+	'internal-slate':         #262a33, //is the same as 'slate', but currently here to enable experimental work on internal brand design without distrupting the palette
 ), $o-colors-palette);
 
 $o-colors-tints: (

--- a/src/scss/_use-cases.scss
+++ b/src/scss/_use-cases.scss
@@ -51,7 +51,7 @@ $branded-usecases: (
 	'internal': (
 	//	<use case>                <properties>
 		page:                     (background: 'white'),
-		box:                      (background: 'wheat'),
+		box:                      (background: 'internal-slate-5'),
 		link:                     (text: 'teal'),
 		link-hover:               (text: 'internal-slate-15'),
 		link-title:               (text: 'internal-slate-15'),
@@ -61,4 +61,4 @@ $branded-usecases: (
 	)
 );
 
-$o-colors-usecases: if(map-get($branded-usecases, $o-brand), (map-merge(map-get($branded-usecases, $o-brand), $o-colors-usecases)), ());
+$o-colors-usecases: if(map-get($branded-usecases, $o-colors-brand), (map-merge(map-get($branded-usecases, $o-colors-brand), $o-colors-usecases)), ());

--- a/src/scss/_use-cases.scss
+++ b/src/scss/_use-cases.scss
@@ -61,4 +61,7 @@ $branded-usecases: (
 	)
 );
 
-$o-colors-usecases: (map-merge(map-get($branded-usecases, $o-brand), $o-colors-usecases));
+$o-brand: 'lalala';
+$o-colors-usecases: if(map-get($branded-usecases, $o-brand), (map-merge(map-get($branded-usecases, $o-brand), $o-colors-usecases)), ());
+
+@debug $o-colors-usecases;

--- a/src/scss/_use-cases.scss
+++ b/src/scss/_use-cases.scss
@@ -62,5 +62,3 @@ $branded-usecases: (
 );
 
 $o-colors-usecases: (map-merge(map-get($branded-usecases, $o-brand), $o-colors-usecases));
-
-@debug $o-colors-usecases;

--- a/src/scss/_use-cases.scss
+++ b/src/scss/_use-cases.scss
@@ -61,7 +61,4 @@ $branded-usecases: (
 	)
 );
 
-$o-brand: 'lalala';
 $o-colors-usecases: if(map-get($branded-usecases, $o-brand), (map-merge(map-get($branded-usecases, $o-brand), $o-colors-usecases)), ());
-
-@debug $o-colors-usecases;

--- a/src/scss/_use-cases.scss
+++ b/src/scss/_use-cases.scss
@@ -17,7 +17,10 @@
 ///                     _deprecated: <msg>  Emits <msg> as a warning if referenced, but still works
 ///
 /// @type map
-$branded-usecases: (
+
+//TODO: Include explanation for mapped usecases once they have been made permanent and publicly available
+
+$_o-colors-branded-usecases: (
 	'master': (
 	//	<use case>                <properties>
 		page:                     (background: 'paper'),
@@ -56,9 +59,29 @@ $branded-usecases: (
 		link-hover:               (text: 'internal-slate-15'),
 		link-title:               (text: 'internal-slate-15'),
 		link-title-hover:         (text: 'internal-slate-15'),
+		tag-link:                 (text: 'claret', _deprecated: 'It is not a valid usecase for the "internal" brand. Please contact Origami if you have any questions.'),
+		tag-link-hover:           (text: 'claret-30', _deprecated: 'It is not a valid usecase for the "internal" brand. Please contact Origami if you have any questions.'),
+		opinion-tag-link:         (text: 'oxford', _deprecated: 'It is not a valid usecase for the "internal" brand. Please contact Origami if you have any questions.'),
+		opinion-tag-link-hover:   (text: 'oxford-30', _deprecated: 'It is not a valid usecase for the "internal" brand. Please contact Origami if you have any questions.'),
 		title:                    (text: 'internal-slate'),
 		body:                     (text: 'internal-slate'),
+		muted:                    (text: 'black-20', _deprecated: 'It is not a valid usecase for the "internal" brand. Please contact Origami if you have any questions.'),
+		opinion:                  (background: 'sky', _deprecated: 'It is not a valid usecase for the "internal" brand. Please contact Origami if you have any questions.'),
+		hero:                     (background: 'wheat', _deprecated: 'It is not a valid usecase for the "internal" brand. Please contact Origami if you have any questions.'),
+		hero-opinion:             (background: 'oxford', _deprecated: 'It is not a valid usecase for the "internal" brand. Please contact Origami if you have any questions.'),
+		hero-highlight:           (background: 'claret', _deprecated: 'It is not a valid usecase for the "internal" brand. Please contact Origami if you have any questions.'),
+
+
+	// Section colors
+	section-life-arts:        (all: 'velvet', _deprecated: 'It is not a valid usecase for the "internal" brand. Please contact Origami if you have any questions.'),
+	section-life-arts-alt:    (all: 'candy', _deprecated: 'It is not a valid usecase for the "internal" brand. Please contact Origami if you have any questions.'),
+	section-magazine:         (all: 'oxford', _deprecated: 'It is not a valid usecase for the "internal" brand. Please contact Origami if you have any questions.'),
+	section-magazine-alt:     (all: 'sky', _deprecated: 'It is not a valid usecase for the "internal" brand. Please contact Origami if you have any questions.'),
+	section-house-home:       (all: 'jade', _deprecated: 'It is not a valid usecase for the "internal" brand. Please contact Origami if you have any questions.'),
+	section-house-home-alt:   (all: 'wasabi', _deprecated: 'It is not a valid usecase for the "internal" brand. Please contact Origami if you have any questions.'),
+	section-money:            (all: 'crimson', _deprecated: 'It is not a valid usecase for the "internal" brand. Please contact Origami if you have any questions.'),
+	section-money-alt:        (all: 'white', _deprecated: 'It is not a valid usecase for the "internal" brand. Please contact Origami if you have any questions.'),
 	)
 );
 
-$o-colors-usecases: if(map-get($branded-usecases, $o-colors-brand), (map-merge(map-get($branded-usecases, $o-colors-brand), $o-colors-usecases)), ());
+$o-colors-usecases: if(map-get($_o-colors-branded-usecases, $_o-colors-brand), (map-merge(map-get($_o-colors-branded-usecases, $_o-colors-brand), $o-colors-usecases)), ());

--- a/src/scss/_use-cases.scss
+++ b/src/scss/_use-cases.scss
@@ -17,36 +17,50 @@
 ///                     _deprecated: <msg>  Emits <msg> as a warning if referenced, but still works
 ///
 /// @type map
-$o-colors-usecases: map-merge((
+$branded-usecases: (
+	'master': (
+	//	<use case>                <properties>
+		page:                     (background: 'paper'),
+		box:                      (background: 'wheat'),
+		link:                     (text: 'teal'),
+		link-hover:               (text: 'black-70'),
+		link-title:               (text: 'black-80'),
+		link-title-hover:         (text: 'black-70'),
+		tag-link:                 (text: 'claret'),
+		tag-link-hover:           (text: 'claret-30'),
+		opinion-tag-link:         (text: 'oxford'),
+		opinion-tag-link-hover:   (text: 'oxford-30'),
+		title:                    (text: 'black'),
+		body:                     (text: 'black-80'),
+		muted:                    (text: 'black-20'),
+		opinion:                  (background: 'sky'),
+		hero:                     (background: 'wheat'),
+		hero-opinion:             (background: 'oxford'),
+		hero-highlight:           (background: 'claret'),
 
-//	<use case>                <properties>
+		// Section colors
+		section-life-arts:        (all: 'velvet'),
+		section-life-arts-alt:    (all: 'candy'),
+		section-magazine:         (all: 'oxford'),
+		section-magazine-alt:     (all: 'sky'),
+		section-house-home:       (all: 'jade'),
+		section-house-home-alt:   (all: 'wasabi'),
+		section-money:            (all: 'crimson'),
+		section-money-alt:        (all: 'white'),
+	),
+	'internal': (
+	//	<use case>                <properties>
+		page:                     (background: 'white'),
+		box:                      (background: 'wheat'),
+		link:                     (text: 'teal'),
+		link-hover:               (text: 'internal-slate-15'),
+		link-title:               (text: 'internal-slate-15'),
+		link-title-hover:         (text: 'internal-slate-15'),
+		title:                    (text: 'internal-slate'),
+		body:                     (text: 'internal-slate'),
+	)
+);
 
-	page:                     (background: 'paper'),
-	box:                      (background: 'wheat'),
-	link:                     (text: 'teal'),
-	link-hover:               (text: 'black-70'),
-	link-title:               (text: 'black-80'),
-	link-title-hover:         (text: 'black-70'),
-	tag-link:                 (text: 'claret'),
-	tag-link-hover:           (text: 'claret-30'),
-	opinion-tag-link:         (text: 'oxford'),
-	opinion-tag-link-hover:   (text: 'oxford-30'),
-	title:                    (text: 'black'),
-	body:                     (text: 'black-80'),
-	muted:                    (text: 'black-20'),
-	opinion:                  (background: 'sky'),
-	hero:                     (background: 'wheat'),
-	hero-opinion:             (background: 'oxford'),
-	hero-highlight:           (background: 'claret'),
+$o-colors-usecases: (map-merge(map-get($branded-usecases, $o-brand), $o-colors-usecases));
 
-	// Section colors
-	section-life-arts:        (all: 'velvet'),
-	section-life-arts-alt:    (all: 'candy'),
-	section-magazine:         (all: 'oxford'),
-	section-magazine-alt:     (all: 'sky'),
-	section-house-home:       (all: 'jade'),
-	section-house-home-alt:   (all: 'wasabi'),
-	section-money:            (all: 'crimson'),
-	section-money-alt:        (all: 'white'),
-
-), $o-colors-usecases);
+@debug $o-colors-usecases;

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -3,4 +3,4 @@ $o-colors-is-silent: true !default;
 $o-colors-palette: () !default;
 $o-colors-usecases: () !default;
 
-$_o-colors-brand: if(global-variable-exists(o-brand), $o-brand, 'master');
+$_o-colors-brand: if(global-variable-exists(o-brand), if($o-brand != null, $o-brand, 'master'), 'master');

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -2,3 +2,5 @@ $o-colors-is-silent: true !default;
 
 $o-colors-palette: () !default;
 $o-colors-usecases: () !default;
+
+$o-brand: 'master' !default;

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -3,4 +3,4 @@ $o-colors-is-silent: true !default;
 $o-colors-palette: () !default;
 $o-colors-usecases: () !default;
 
-$o-brand: 'master' !default;
+$o-colors-brand: if(global-variable-exists(o-brand), $o-brand, 'master');

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -3,4 +3,4 @@ $o-colors-is-silent: true !default;
 $o-colors-palette: () !default;
 $o-colors-usecases: () !default;
 
-$o-colors-brand: if(global-variable-exists(o-brand), $o-brand, 'master');
+$_o-colors-brand: if(global-variable-exists(o-brand), $o-brand, 'master');


### PR DESCRIPTION
As agreed with Mark Hale, this adds two 'new' colours to the palette, which are for experimental use only.

For the sake of separation, this includes `internal-slate` which has the same hex value as `slate` but is treated differently in terms of tinting/mixing. The two 'tints' are `internal-slate-5` and `internal-slate-15`. This should allow us to apply colour consistency across branded components.

Though `o-colors` is branded, it doesn't use `o-brand` (yet), because we've found that due to the way  in which `o-brand` is constructed, it won't accept  variables as maps, which is a need we've only found for `o-colors` so far, which doesn't justify adding the functionality to `o-brand`. Instead, the usecases have been mapped to `master` and `internal` keys, which return usecases based on their respective colour palettes, and will change only if there is  an`$o-brand` variable in place in whichever component uses `o-colors`. 

The new colours haven't been added to the demo palette, and this won't be a big festive release — it isn't a breaking change. I've added a warning to the mixin that fetches palette colours, in the off chance someone does find the new colour and chooses to use it. 