### PR TITLE
Update the default `oColorsMix` background.

### DIFF
--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -25,7 +25,7 @@
 /// @param {String} $background [paper] - palette name of background color
 /// @param {String} $color [black] - palette name of color
 /// @param {Number} $percentage [60] - percentage opacity of the color over the background
-@function oColorsMix($color: 'black', $background: 'paper', $percentage: 80) {
+@function oColorsMix($color: 'black', $background: oColorsGetUseCase('page', 'background'), $percentage: 80) {
 	$context: $background;
 	$base: $color;
 


### PR DESCRIPTION
Use page background.

For the default  "master" brand:
- no change (unless a custom page background has been set)

For the "internal" brand:
- white tints are redundant
- black tints now look like the following

<img width="1116" alt="screen shot 2018-03-19 at 14 47 29" src="https://user-images.githubusercontent.com/10405691/37602749-f60ed95a-2b84-11e8-872f-d2abab8fb921.png">

See comment for suggestion to hide the white tints for the internal brand: https://github.com/Financial-Times/o-colors/issues/144