### PR TITLE
Remove warning as it is spamming clients.

### DIFF
--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -8,11 +8,6 @@
 /// @param {String} $name
 @function oColorsGetPaletteColor($name) {
 	@if (map-has-key($o-colors-palette, $name)) {
-
-		@if map-has-key($_o-colors-experimental-palette, $name) {
-			@warn "This color is not officially a part of the o-colors palette. It is for experimental use, and may be removed at any time.";
-		}
-
 		@return map-get($o-colors-palette, $name);
 	} @else {
 		@warn "Color name '#{inspect($name)}' is not defined in the palette";

--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -8,6 +8,13 @@
 /// @param {String} $name
 @function oColorsGetPaletteColor($name) {
 	@if (map-has-key($o-colors-palette, $name)) {
+
+		// Warn if an experimental palette color is being used.
+		@if $_o-colors-experimental-palette-warning and map-has-key($_o-colors-experimental-palette, $name) {
+			$_o-colors-experimental-palette-warning: false !global;
+			@warn "Please note: The palette colors #{map-keys($_o-colors-experimental-palette)} are experimental and may be removed at any time. No action is required if you are not using these colors directly.";
+		}
+
 		@return map-get($o-colors-palette, $name);
 	} @else {
 		@warn "Color name '#{inspect($name)}' is not defined in the palette";

--- a/src/scss/_palette.scss
+++ b/src/scss/_palette.scss
@@ -56,6 +56,9 @@ $o-colors-palette: map-merge((
 	'org-b2c-light':         #99c6fb,
 ), $o-colors-palette);
 
+// Add experimental colors to support work on internal brand design.
+$o-colors-palette: map-merge($_o-colors-experimental-palette, $o-colors-palette);
+
 $o-colors-tints: (
 	'black': (
 		tints: (5, 10, 20, 30, 40, 50, 60, 70, 80, 90),
@@ -119,10 +122,3 @@ $o-colors-tints: (
 		saturation: 100,
 	)
 );
-
-// Add experimental colors to support work on internal brand design.
-$_o-colors-experimental-palette: (
-	'slate-white-15':        #dedfe0, // oColorsMix('slate', 'white', 15): to support work on internal brand design
-	'slate-white-5':         #f4f4f5, // oColorsMix('slate', 'white', 5): to support work on internal brand design
-);
-$o-colors-palette: map-merge($_o-colors-experimental-palette, $o-colors-palette);

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -1,6 +1,11 @@
 $o-colors-is-silent: true !default;
 
 $o-colors-palette: () !default;
+$_o-colors-experimental-palette: (
+	'slate-white-15':        #dedfe0, // oColorsMix('slate', 'white', 15): to support work on internal brand design
+	'slate-white-5':         #f4f4f5, // oColorsMix('slate', 'white', 5): to support work on internal brand design
+);
+$_o-colors-experimental-palette-warning: true !default;
 $o-colors-usecases: () !default;
 
 $_o-colors-brand: if(global-variable-exists(o-brand), if($o-brand != null, $o-brand, 'master'), 'master');


### PR DESCRIPTION
As we are using experimental colours in components now this is spamming clients (e.g. the apps team), even if they are not using the internal brand or experimental colours directly.

Although not ideal, I think we're probably safe to remove the warning so long as the colours are hidden from documentation.