### PR TITLE
silence null warnings

### DIFF
--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -87,7 +87,7 @@
 ///
 /// @param {list} $namelist
 /// @param {String} $property [all]
-/// @param {map} $options [('default': false)] - default: fallback value (false, null, or one of $o-colors-palette)
+/// @param {map} $options [('default': false)] - default: fallback value (false, null, or oColorsGetPaletteColor($palette-color));
 @function oColorsGetColorFor($namelist, $property: all, $options: ('default': false)) {
 	$default: map-get($options, 'default');
 	$color: null;
@@ -100,7 +100,7 @@
 
 	@if ($color == null) {
 		@if ($default or $default == null) {
-			@return oColorsGetPaletteColor($default);
+			@return $default;
 		} @else {
 			$warn: "Undefined use-case: can't resolve use case list '#{inspect($namelist)}'";
 

--- a/test/scss/_functions.test.scss
+++ b/test/scss/_functions.test.scss
@@ -82,7 +82,7 @@
 
 			@include it('and assigns a fallback in case of non existent use case') {
 				@include assert-equal(
-				oColorsGetColorFor(test-link, text, $options: ('default': 'teal-20')),
+				oColorsGetColorFor(test-link, text, $options: ('default': oColorsGetPaletteColor('teal-20'))),
 				(oColorsGetPaletteColor('teal-20')));
 			};
 		};


### PR DESCRIPTION
This fixes a warning that was being caught if a null value was being supplied. 
Seeing as null is ignored by sass, we don't need to catch this. 