### PR TITLE
Correct the "link-hover" usecase.

### DIFF
--- a/src/scss/_use-cases.scss
+++ b/src/scss/_use-cases.scss
@@ -26,7 +26,7 @@ $_o-colors-branded-usecases: (
 		page:                     (background: 'paper'),
 		box:                      (background: 'wheat'),
 		link:                     (text: 'teal'),
-		link-hover:               (text: 'black-70'),
+		link-hover:               (text: 'teal-30'),
 		link-title:               (text: 'black-80'),
 		link-title-hover:         (text: 'black-70'),
 		tag-link:                 (text: 'claret'),

--- a/test/scss/_functions.test.scss
+++ b/test/scss/_functions.test.scss
@@ -41,7 +41,7 @@
 			@include assert-equal(oColorsGetUseCase(page, background), ('paper'));
 			@include assert-equal(oColorsGetUseCase(box, background), ('wheat'));
 			@include assert-equal(oColorsGetUseCase(link, text), ('teal'));
-			@include assert-equal(oColorsGetUseCase(link-hover, text), ('black-70'));
+			@include assert-equal(oColorsGetUseCase(link-hover, text), ('teal-30'));
 			@include assert-equal(oColorsGetUseCase(link-title, text), ('black-80'));
 			@include assert-equal(oColorsGetUseCase(link-title-hover, text), ('black-70'));
 			@include assert-equal(oColorsGetUseCase(tag-link, text), ('claret'));


### PR DESCRIPTION
Correct the "link-hover" usecase to align to `o-typography`. 

Will follow up with an update to `o-typography` to use this corrected usecase. It's odd because `o-typography` does use the "link" usecase.
https://github.com/Financial-Times/o-typography/blob/b327713245705ce3091cf2f8087733fa23872c6f/src/scss/use-cases/_general.scss#L45

A quick look through visible repositories on Github revealed no reason not to correct this.