### PR TITLE
Correct the brand semver.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,6 +9,6 @@
   ],
   "dependencies": {
     "mathsass": "^0.10.1",
-    "o-brand": "^3.1.0"
+    "o-brand": ">=2.3.0 <4"
   }
 }


### PR DESCRIPTION
Commits from [here](https://github.com/Financial-Times/o-colors/pull/165) which add a dependancy on `o-brand` where in master but not released.