### PR TITLE
Add focus outline to usecases.

### DIFF
--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -56,7 +56,7 @@
 ///
 ///
 /// @param {String} $usecase
-/// @param {String} $property - 'text', 'background', 'border' or 'all'
+/// @param {String} $property - 'text', 'background', 'border', 'outline', or 'all'
 @function oColorsGetUseCase($usecase, $property) {
 	@if (not map-has-key($o-colors-usecases, $usecase)) {
 		@return null;

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -85,6 +85,10 @@
 	@if ($propertyList == 'all' or index($propertyList, 'border')) {
 		border-color: oColorsGetColorFor($useCaseList, border, $options: $args);
 	}
+
+	@if ($propertyList == 'all' or index($propertyList, 'outline')) {
+		outline-color: oColorsGetColorFor($useCaseList, outline, $options: $args);
+	}
 }
 
 /// Update the palette with calculated tints of

--- a/src/scss/_use-cases.scss
+++ b/src/scss/_use-cases.scss
@@ -40,6 +40,7 @@ $_o-colors-branded-usecases: (
 		hero:                     (background: 'wheat'),
 		hero-opinion:             (background: 'oxford'),
 		hero-highlight:           (background: 'claret'),
+		focus:                    (outline: 'teal-100'),
 
 		// Section colors
 		section-life-arts:        (all: 'velvet'),
@@ -62,6 +63,7 @@ $_o-colors-branded-usecases: (
 		title:                    (text: 'slate'),
 		body:                     (text: 'slate'),
 		muted:                    (text: 'black-20'),
+		focus:                    (outline: 'teal-100'),
 	),
 	'whitelabel': (
 	//	<use case>                <properties>

--- a/test/scss/_functions.test.scss
+++ b/test/scss/_functions.test.scss
@@ -55,6 +55,7 @@
 			@include assert-equal(oColorsGetUseCase(hero, background), ('wheat'));
 			@include assert-equal(oColorsGetUseCase(hero-opinion, background), ('oxford'));
 			@include assert-equal(oColorsGetUseCase(hero-highlight, background), ('claret'));
+			@include assert-equal(oColorsGetUseCase(focus, outline), ('teal-100'));
 			@include assert-equal(oColorsGetUseCase(section-life-arts, all), ('velvet'));
 			@include assert-equal(oColorsGetUseCase(section-life-arts-alt, all), ('candy'));
 			@include assert-equal(oColorsGetUseCase(section-magazine, all), ('oxford'));


### PR DESCRIPTION
- Add support for 'outline' property.
- Add focus outline usecase.

`o-normalise` can use this usecase in its next major:
https://github.com/Financial-Times/o-normalise/blob/bca3c6904f4dde4238749baa599101f979072932/src/scss/_variables.scss#L16

`o-typography` can use it now:
https://github.com/Financial-Times/o-typography/blob/31a3ab52aaf98911292e44e9b5e2779e6d6b87fd/src/scss/use-cases/_general.scss#L23