### PR TITLE
Do not warn when standard usecases are undefined.

### DIFF
--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -5,7 +5,7 @@
 
 /// Return the CSS color for a palette color name
 ///
-/// @param {String} $name
+/// @param {String|Color|Null} $name
 @function oColorsGetPaletteColor($name) {
 	@if (map-has-key($o-colors-palette, inspect($name))) {
 		$color: map-get($o-colors-palette, inspect($name));
@@ -25,7 +25,7 @@
 		}
 
 		@return $color;
-	} @else if type-of($name) != color {
+	} @else if $name != null and type-of($name) != color {
 		@warn "Color name '#{inspect($name)}' is not defined in the palette.";
 		@return null;
 	} @else {
@@ -97,6 +97,7 @@
 /// @param {list} $namelist
 /// @param {String} $property [all]
 /// @param {map} $options [('default': false)] - default: fallback value (false, null, or oColorsGetPaletteColor($palette-color));
+/// @return {String|Color|Null}
 @function oColorsGetColorFor($namelist, $property: all, $options: ('default': false)) {
 	$default: map-get($options, 'default');
 	$color: null;
@@ -107,18 +108,16 @@
 		}
 	}
 
-	@if ($color == null) {
-		@if ($default or $default == null) {
-			@return $default;
-		} @else {
-			$warn: "Undefined use-case: can't resolve use case list '#{inspect($namelist)}'";
+	@if ($color == null and ($default or $default == null)) {
+		@return $default;
+	}
 
-			@if ($property) {
-				$warn: $warn + " for property '#{inspect($property)}'";
-			}
-
-			@warn $warn;
+	@if(not index($_o-colors-ignore-usecases-warnings, $namelist)) {
+		$warn: "Undefined use-case: can't resolve use case list '#{inspect($namelist)}'";
+		@if ($property) {
+			$warn: $warn + " for property '#{inspect($property)}'";
 		}
+		@warn $warn;
 	}
 
 	@return oColorsGetPaletteColor($color);

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -12,4 +12,9 @@ $_o-colors-experimental-palette-warning: null !default;
 
 $o-colors-usecases: () !default;
 
+// These are common usecase which are not necessarily defined for each brand.
+// When the usecase is used and `null` is returned, there is no need to warn about it.
+// Warning is still useful in other cases to highlight misspelled usecases, or missing custom usecases.
+$_o-colors-ignore-usecases-warnings: ('page', 'box', 'link', 'link-hover', 'link-title', 'link-title-hover', 'title', 'body', 'muted');
+
 $_o-colors-test-environment: false !default;


### PR DESCRIPTION
**Changes** 

- `oColorsGetColorFor` does not warn if common usecases like 'page' are not set.
- `oColorsGetPaletteColor` does not warn when trying to get a color for a `null` usecase.
- Updated Sassdoc return annotation (the return types haven't changed though).

**Why** 

These are common usecase which are not necessarily defined for each brand. When the usecase is used and `null` is returned, there is no need to warn about it. 

E.g. in `o-typography`. There is a warning when calling `color: oColorsGetColorFor('body', 'text');` for the internal brand, but not setting a colour for body copy is desired.
<img width="1229" alt="screen shot 2018-11-14 at 16 02 27" src="https://user-images.githubusercontent.com/10405691/48495799-a89d0a00-e828-11e8-8b3d-2835121098ff.png">

Warning is still useful in other cases to highlight misspelled usecases, or missing custom usecases. 

We might want to solve this in a more robust way in the future, pending the future of custom usecases.