### PR TITLE
Prevent warning when color usecase is resolved.

### DIFF
--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -112,7 +112,7 @@
 		@return $default;
 	}
 
-	@if(not index($_o-colors-ignore-usecases-warnings, $namelist)) {
+	@if($color == null and not index($_o-colors-ignore-usecases-warnings, $namelist)) {
 		$warn: "Undefined use-case: can't resolve use case list '#{inspect($namelist)}'";
 		@if ($property) {
 			$warn: $warn + " for property '#{inspect($property)}'";


### PR DESCRIPTION
There was a mistake [in my last PR ](https://github.com/Financial-Times/o-colors/pull/174)which means o-colors is spamming usecase warnings, even when the usecase is resolved. 