### PR TITLE
Silence color palette deprecations for internal/whitelabel brands.

### DIFF
--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -16,7 +16,7 @@
 
 		//check if it is deprecated
 		@if type-of($color) == list {
-			@if nth($color, 2) == '_deprecated' {
+			@if nth($color, 2) == '_deprecated' and $_o-colors-deprecated-palette-color-warnings {
 				@warn "#{$name} is deprecated for the #{$_o-colors-brand} palette, and will be removed in the next major.";
 			}
 

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -17,4 +17,10 @@ $o-colors-usecases: () !default;
 // Warning is still useful in other cases to highlight misspelled usecases, or missing custom usecases.
 $_o-colors-ignore-usecases-warnings: ('page', 'box', 'link', 'link-hover', 'link-title', 'link-title-hover', 'title', 'body', 'muted');
 
+// Whether to show deprecated palette color warnings.
+// v4 of o-colors has many deprecations for the internal and whtielabel brands.
+// These still effect our components, so users are spammed with warnings they cannot solve.
+// So suppress these warnings. The deprecated colors will be removed in the next major.
+$_o-colors-deprecated-palette-color-warnings: oBrandGetCurrentBrand() == 'master' !default;
+
 $_o-colors-test-environment: false !default;


### PR DESCRIPTION
v4 of o-colors has many palette color deprecations for the internal and whtielabel brands.
These still effect our components, e.g. o-buttons, so users are spammed with warnings they cannot solve. So suppress these warnings until the deprecated colors are removed in the next major.