### PR TITLE
Remove experimental internal pallete warnings.

### DIFF
--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -22,11 +22,6 @@
 
 			$color: nth($color, 1);
 		}
-		// Warn if an experimental palette color is being used.
-		@if $_o-colors-experimental-palette-warning and map-has-key($_o-colors-experimental-palette, $name-string) {
-			$_o-colors-experimental-palette-warning: false !global;
-			@warn "Please note: The palette colors #{map-keys($_o-colors-experimental-palette)} are experimental and may be removed at any time. No action is required if you are not using these colors directly.";
-		}
 
 		@return $color;
 	} @else if $name != null and type-of($name) != color {

--- a/src/scss/_palette.scss
+++ b/src/scss/_palette.scss
@@ -68,9 +68,6 @@ $_o-colors-brand: oBrandGetCurrentBrand();
 }
 
 @if $_o-colors-brand == internal {
-	// Set warning, avoid outputting it twice
-	$_o-colors-experimental-palette-warning: if($_o-colors-experimental-palette-warning == null, true, $_o-colors-experimental-palette-warning) !global;
-
 	$o-colors-palette: map-merge((
 	// primary palette
 	'oxford':          #0f5499,
@@ -126,10 +123,10 @@ $_o-colors-brand: oBrandGetCurrentBrand();
 	'org-b2c-dark':   (#3a70af, '_deprecated'),
 	'org-b2c-light':  (#99c6fb, '_deprecated'),
 	), $o-colors-palette);
-}
 
-// Add experimental colors to support work on internal brand design.
-$o-colors-palette: if($_o-colors-brand == internal, map-merge($_o-colors-experimental-palette, $o-colors-palette), $o-colors-palette);
+	// Add experimental colors to support work on the internal brand design.
+	$o-colors-palette: map-merge($_o-colors-experimental-internal-palette, $o-colors-palette);
+}
 
 @if $_o-colors-brand == master {
 	$o-colors-tints: map-merge((

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -3,12 +3,10 @@ $o-colors-is-silent: true !default;
 $o-colors-palette: () !default;
 $o-colors-tints: () !default;
 
-$_o-colors-experimental-palette: (
+$_o-colors-experimental-internal-palette: (
 	'slate-white-15':        #dedfe0, // oColorsMix('slate', 'white', 15): to support work on internal brand design
 	'slate-white-5':         #f4f4f5, // oColorsMix('slate', 'white', 5): to support work on internal brand design
 );
-
-$_o-colors-experimental-palette-warning: null !default;
 
 $o-colors-usecases: () !default;
 

--- a/test/scss/_master.test.scss
+++ b/test/scss/_master.test.scss
@@ -6,12 +6,10 @@ $_o-colors-brand: if(global-variable-exists(o-brand), if($o-brand != null, $o-br
 $o-colors-palette: () !global;
 $o-colors-tints: () !global;
 
-$_o-colors-experimental-palette: (
+$_o-colors-experimental-internal-palette: (
 	'slate-white-15':        #dedfe0, // oColorsMix('slate', 'white', 15): to support work on internal brand design
 	'slate-white-5':         #f4f4f5, // oColorsMix('slate', 'white', 5): to support work on internal brand design
 );
-
-$_o-colors-experimental-palette-warning: false !global;
 
 $o-colors-usecases: () !global;
 


### PR DESCRIPTION
We currently warn that the internal brand colors 'slate-white-15' and 'slate-white-5' are experimental and may be removed at any time. As we use the colours in our own components users can't do anything to prevent the warning, so it's a bit spammy. 

Also, as the colours have been in production for months, in might be considered a little clinical to take them away without a major even though we warn about it. We have a new major of o-colors due anyway, so let's remove those warnings and deprecate like usual when/if we need to.

Until their name and application is cemented within the net major, they're still shown as experimental in the code and in the registry. We're just not going to warn about it or take them away without a major.