### PR TITLE
fix edge case for contrast calculation

### DIFF
--- a/demos/src/contrast-checker/contrast-checker.scss
+++ b/demos/src/contrast-checker/contrast-checker.scss
@@ -157,7 +157,7 @@ body {
 
 	.contrast-combination {
 		margin-bottom: 12px;
-		max-width: 280px;
+		max-width: 3200px;
 
 		.o-forms-title__main {
 			display: inline-block;

--- a/demos/src/contrast-checker/contrast-checker.scss
+++ b/demos/src/contrast-checker/contrast-checker.scss
@@ -157,7 +157,7 @@ body {
 
 	.contrast-combination {
 		margin-bottom: 12px;
-		max-width: 3200px;
+		max-width: 320px;
 
 		.o-forms-title__main {
 			display: inline-block;

--- a/demos/src/shared/contrast-ratio.js
+++ b/demos/src/shared/contrast-ratio.js
@@ -42,6 +42,7 @@ function preciseFloor(number, decimals = 2) {
 }
 
 function oColorsColorLuminance(hex) {
+	hex = hex.trim() === 'gray' ? '#808080' : hex; // an equal mix of black and white will always default to 'gray' instead of a hex value
 	const hexValue = hex.replace('#', '').trim();
 	const rgbPairs = hexValue.match(/.{1,2}/g);
 


### PR DESCRIPTION
For some reason I haven't managed to figure out, `#808080` (`'black-50'`) defaults to `'gray'` 🤔 and that causes a `NaN` contrast ratio calculation.