### PR TITLE
Suppress warnings which are output by default with silient mode off.

### DIFF
--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -154,7 +154,8 @@
 ///
 /// @param {Color} $background - the hex color of the background the text will appear on
 /// @param {Number} $opacity [100] - the opacity percentage the text color should appear at
-@function oColorsGetTextColor($backgroundd, $opacity: 90) {
+/// @param {Boolean} $warnings [true] - whether this function should throw WCAG contrast check warnings/errors
+@function oColorsGetTextColor($backgroundd, $opacity: 90, $warnings: true) {
 	$background: oColorsGetPaletteColor($backgroundd);
 
 	@if $background == null or type-of($background) != color {
@@ -172,9 +173,11 @@
 		$testContrast: oColorsCheckContrast($textColor, $background, false);
 	}
 
-	@if not $testContrast {
+	@if not $testContrast and $warnings == true {
 		@return _error("The combination of #{$opacity}% #{$baseColor} on #{$background} does not pass WCAG guidelines for color contrast.");
-	} @else if $testContrast == 'large' {
+	}
+
+	@if $testContrast == 'large' and $warnings == true {
 		@warn "When using this combination (#{$opacity}% #{$baseColor} on #{$background}) please use a font size larger than 18px.";
 	}
 

--- a/test/scss/_functions.test.scss
+++ b/test/scss/_functions.test.scss
@@ -109,5 +109,12 @@
 		@include it('returns a text color based on background and opacity percentage') {
 			@include assert-equal(oColorsGetTextColor(oColorsGetPaletteColor('paper')), (#1a1817));
 		};
+		@include it('throws an error if a text color and background does not pass WCAG contrast guidelines') {
+			@include assert-equal(oColorsGetTextColor(oColorsGetPaletteColor('black-40'), 50),
+			('ERROR: The combination of 50% black on #999189 does not pass WCAG guidelines for color contrast.'));
+		};
+		@include it('does not throw an error when a text color and background does not pass WCAG contrast guidelines and warnings are disabled') {
+			@include assert-equal(oColorsGetTextColor(oColorsGetPaletteColor('black-40'), 50, $warnings: false),  #4d4945);
+		};
 	};
 };


### PR DESCRIPTION
o-colors outputs a CSS class for each colour in our pallete
to apply the colour as a background, with a foreground of
either black or white. This throws a warning for some combinations
where the contrast is not high enough (wihout 18px typography).

These classes may not be very helpful and should be reconsidered
now CSS Custom Properties are viable for many of our build
service users.

In the meantime we can suppress these default warnings
as they are a nuisance and not useful for Sass users who
are including o-colors with silient mode disabled.