### PR TITLE
Add a primary mixin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,26 @@ There are a number of ways of using colors in your component or product. o-color
 
 ### Sass:
 
-As with all Origami components, o-colors has a [silent mode](http://origami.ft.com/docs/syntax/scss/#silent-styles). To use its compiled CSS (rather than incorporating its mixins into your own Sass) set `$o-colors-is-silent : false;` in your Sass before you import the o-colors Sass:
+We recommend Sass projects use the [mixins and functions](#mixins-and-functions) `o-colors` provides directly in their own Sass. However it is also possible to output all `o-colors` CSS classes including [CSS custom properties](#css-variables) using the `oColors` mixin.
 
 ```scss
-$o-colors-is-silent: false;
 @import 'o-colors/main';
+@include oColors();
 ```
+
+The `oColors` mixin accepts an `$opts` argument to granularly include `o-colors` CSS:
+
+```scss
+@include oColors($opts: (
+	'palette-custom-properties': true // output just css custom properties "css variables"
+));
+```
+
+| Feature                   | Description                                                                                                                         |
+|---------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
+| palette-custom-properties | Output a [CSS custom property (CSS Variable)](#css-variables) for each colour in the palette.                                       |
+| palette-classes           | Output CSS classes which apply a background for each palette colour, see the [markup section](#markup) for a list of these classes. |
+| usecase-classes           | Output CSS classes for each colour usecase, see the [markup section](#markup) for a list of these classes.                          |
 
 #### Colors and accessibility
 
@@ -181,7 +195,7 @@ You can also use `oColorsGetUseCase` to retrieve the palette color name (eg `pap
 
 ### Markup
 
-When using the build service or importing the module with [silent mode](http://origami.ft.com/docs/syntax/scss/#silent-styles) set to false, o-colors provides you with helper classes to access the color palette. All palette colors are available as `.o-colors-palette-[NAME]` (which style just `background-color`) and use cases are available as `.o-colors-[USECASE]-[PROPERTY]` (which style the appropriate property):
+When using the [Build Service](https://origami.ft.com/docs/services/#build-service) or the [`oColors` mixin](#sass), `o-colors` provides you with helper classes to access the color palette. All palette colors are available as `.o-colors-palette-[NAME]` (which style just `background-color`) and use cases are available as `.o-colors-[USECASE]-[PROPERTY]` (which style the appropriate property):
 
 ```html
 <p class="o-colors-body-text">Article text</p>
@@ -221,7 +235,7 @@ section-money-alt |     all
 
 ### CSS Variables
 
-When using the build service or importing the module with silent mode set to false, o-colors will output all the palette colors as [CSS Variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_variables). These will use the format `--o-colors-{name}` (e.g. `--o-colors-black` and `--o-colors-teal`).
+When using the [Build Service](https://origami.ft.com/docs/services/#build-service) or the [`oColors` mixin](#sass), `o-colors` will output all the palette colors as [CSS custom properties (CSS Variables)](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_variables). These will use the format `--o-colors-{name}` (e.g. `--o-colors-black` and `--o-colors-teal`).
 
 
 ## Migration guide

--- a/main.scss
+++ b/main.scss
@@ -16,36 +16,61 @@
 // Set the tint palette colors programatically
 @include _oColorsSetPaletteTints;
 
+/// Output `o-colors` CSS classes and custom properties.
+/// @example Output only `o-colors` CSS custom properties ("CSS variables").
+///     @include oColors($opts: (
+///     	'palette-custom-properties': true
+///     ));
+///
+/// @param {Map} $ops - The o-colors features to output. See the [readme](https://registry.origami.ft.com/components/o-colors) for a full list of options.
+@mixin oColors($ops: (
+	'palette-custom-properties': true,
+	'palette-classes': true,
+	'usecase-classes': true
+)) {
+	$palette-proeprties: map-get($ops, 'palette-custom-properties');
+	$palette-classes: map-get($ops, 'palette-classes');
+	$usecase-classes: map-get($ops, 'usecase-classes');
+
+	@if($palette-proeprties) {
+		@include _oColorsCSSVariables;
+	}
+
+	@if($usecase-classes) {
+		@each $usecase, $props in $o-colors-usecases {
+			@each $prop, $color in $props {
+				#{'.o-colors-' + $usecase + '-' + $prop} {
+					@if $prop == text or $prop == all {
+						color: oColorsGetPaletteColor($color);
+					}
+					@if $prop == background or $prop == all {
+						background-color: oColorsGetPaletteColor($color);
+					}
+					@if $prop == border or $prop == all {
+						border-color: oColorsGetPaletteColor($color);
+					}
+				}
+			}
+		}
+	}
+
+	@if($palette-classes) {
+		@each $name, $value in $o-colors-palette {
+			.o-colors-palette-#{$name} {
+				background-color: oColorsGetPaletteColor($name);
+
+				@if $name != 'transparent' and $name != 'inherit' {
+					color: oColorsGetTextColor($name, 100);
+				}
+			}
+		}
+	}
+}
+
 // If noisy, output helper classes for use cases and palette colors
 @if ($o-colors-is-silent == false) {
-	@include _oColorsCSSVariables;
-
-	@each $usecase, $props in $o-colors-usecases {
-		@each $prop, $color in $props {
-			#{'.o-colors-' + $usecase + '-' + $prop} {
-				@if $prop == text or $prop == all {
-					color: oColorsGetPaletteColor($color);
-				}
-				@if $prop == background or $prop == all {
-					background-color: oColorsGetPaletteColor($color);
-				}
-				@if $prop == border or $prop == all {
-					border-color: oColorsGetPaletteColor($color);
-				}
-			}
-		}
-	}
-
-	@each $name, $value in $o-colors-palette {
-		.o-colors-palette-#{$name} {
-			background-color: oColorsGetPaletteColor($name);
-
-			@if $name != 'transparent' and $name != 'inherit' {
-				color: oColorsGetTextColor($name, 100);
-			}
-		}
-	}
-
+	// Include all classes and custom properties.
+	@include oColors();
 	// Set silent mode back on to avoid multiple outputs of helper classes
 	$o-colors-is-silent: true;
 }

--- a/main.scss
+++ b/main.scss
@@ -22,15 +22,15 @@
 ///     	'palette-custom-properties': true
 ///     ));
 ///
-/// @param {Map} $ops - The o-colors features to output. See the [readme](https://registry.origami.ft.com/components/o-colors) for a full list of options.
-@mixin oColors($ops: (
+/// @param {Map} $opts - The o-colors features to output. See the [readme](https://registry.origami.ft.com/components/o-colors) for a full list of options.
+@mixin oColors($opts: (
 	'palette-custom-properties': true,
 	'palette-classes': true,
 	'usecase-classes': true
 )) {
-	$palette-proeprties: map-get($ops, 'palette-custom-properties');
-	$palette-classes: map-get($ops, 'palette-classes');
-	$usecase-classes: map-get($ops, 'usecase-classes');
+	$palette-proeprties: map-get($opts, 'palette-custom-properties');
+	$palette-classes: map-get($opts, 'palette-classes');
+	$usecase-classes: map-get($opts, 'usecase-classes');
 
 	@if($palette-proeprties) {
 		@include _oColorsCSSVariables;

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -1,4 +1,71 @@
 @include describe('oColors mixins') {
+	@include describe('oColors') {
+		@include it('outputs palette custom properties, palette classes, and usecase classes by default') {
+			@include assert() {
+				@include output($selector: false) {
+					@include oColors();
+				};
+
+				@include contains($selector: false) {
+					:root {
+						--o-colors-white: #ffffff;
+					}
+				};
+			};
+		};
+
+		@include it('palette custom properties with only the "palette-custom-properties" option') {
+			@include assert() {
+				@include output($selector: false) {
+					@include oColors($opts: (
+						'palette-custom-properties': true
+					));
+				};
+
+				@include contains($selector: false) {
+					:root {
+						--o-colors-white: #ffffff;
+					}
+				};
+			};
+		};
+
+		@include it('outputs usecase classes with only the "usecase-classes" option') {
+			@include assert() {
+				@include output($selector: false) {
+					@include oColors($opts: (
+						'usecase-classes': true
+					));
+				};
+
+				@include contains($selector: false) {
+					.o-colors-page-background {
+						background-color: #fff1e5;
+					}
+					.o-colors-link-text {
+						color: #0d7680;
+					}
+				};
+			};
+		};
+		@include it('palette classes with only the "palette-classes" option') {
+			@include assert() {
+				@include output($selector: false) {
+					@include oColors($opts: (
+						'palette-classes': true
+					));
+				};
+
+				@include contains($selector: false) {
+					.o-colors-palette-white {
+						background-color: #ffffff;
+						color: black;
+					}
+				};
+			};
+		};
+	}
+
 	@include describe('oColorsSetColor') {
 		@include it('adds a custom palette color') {
 			@include oColorsSetColor('olive', #808000);


### PR DESCRIPTION
Add an `oColors` [primary (aka mono) mixin](https://github.com/Financial-Times/origami-proposals/issues/6).
References to silient mode are removed, as primary mixins are
intended to replace silient mode from a users point of view.