### PR TITLE
No more mathsass

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,6 @@
     ".travis.yml"
   ],
   "dependencies": {
-    "mathsass": "^0.10.1",
     "o-brand": ">=2.3.0 <4"
   }
 }

--- a/main.scss
+++ b/main.scss
@@ -1,4 +1,3 @@
-@import 'mathsass/dist/math';
 @import 'o-brand/main';
 
 @import 'src/scss/variables';

--- a/src/scss/tools/_color.scss
+++ b/src/scss/tools/_color.scss
@@ -110,3 +110,48 @@
     }
     @return $ret;
 }
+
+// Returns base to the exponent power.
+// @param {Number} $base The base number
+// @param {Number} $exp The exponent to which to raise base
+// @return {Number}
+// @example
+//     pow(4, 2)   // 16
+//     pow(4, -2)  // 0.0625
+//     pow(4, 0.2) // 1.31951
+@function pow ($base, $exp) {
+    @if $exp == floor($exp) {
+        $r: 1;
+        $s: 0;
+        @if $exp < 0 {
+            $exp: $exp * -1;
+            $s: 1;
+        }
+        @while $exp > 0 {
+            @if $exp % 2 == 1 {
+                $r: $r * $base;
+            }
+            $exp: floor($exp * 0.5);
+            $base: $base * $base;
+        }
+        @return if($s != 0, 1 / $r, $r);
+    } @else if $base == 0 and $exp > 0 {
+        @return 0;
+    } @else {
+        $expint: floor($exp);
+        $r1: pow($base, $expint);
+        $r2: _exp(log($base) * ($exp - $expint));
+        @return $r1 * $r2;
+    }
+}
+
+// A good approximation for $x close to 0.
+@function _exp ($x) {
+    $ret: 0;
+    $i: 1;
+    @for $n from 0 to 24 {
+        $ret: $ret + $i;
+        $i: $i * $x / ($n + 1);
+    }
+    @return $ret;
+}

--- a/src/scss/tools/_color.scss
+++ b/src/scss/tools/_color.scss
@@ -155,3 +155,40 @@
     }
     @return $ret;
 }
+
+// Returns the natural logarithm of a number.
+// @param {Number} $x
+// @param {Number} $b The base number
+// @example
+//     log(2)     // 0.69315
+//     log(10)    // 2.30259
+//     log(2, 10) // 0.30103
+@function log ($x, $b: null) {
+    @if $b != null {
+        @return log($x) / log($b);
+    }
+
+    @if $x <= 0 {
+        @return 0 / 0;
+    }
+    $k: nth(frexp($x / $SQRT2), 2);
+    $x: $x / ldexp(1, $k);
+
+    @return $LN2 * $k + _log($x);
+}
+
+// a good aproximation for $x close to 1
+@function _log ($x) {
+    $x: ($x - 1) / ($x + 1);
+    $x2: $x * $x;
+    $i: 1;
+    $s: $x;
+    $sp: null;
+    @while $sp != $s {
+        $x: $x * $x2;
+        $i: $i + 2;
+        $sp: $s;
+        $s: $s + $x / $i;
+    }
+    @return 2 * $s;
+}

--- a/src/scss/tools/_color.scss
+++ b/src/scss/tools/_color.scss
@@ -156,6 +156,9 @@
     @return $ret;
 }
 
+$LN2:   0.6931471805599453;
+$SQRT2: 1.4142135623730951;
+
 // Returns the natural logarithm of a number.
 // @param {Number} $x
 // @param {Number} $b The base number

--- a/src/scss/tools/_color.scss
+++ b/src/scss/tools/_color.scss
@@ -93,3 +93,20 @@
 	$multiplier: pow(10, $decimals);
 	@return floor($number * $multiplier) / $multiplier;
 }
+
+// Returns the square root of a number.
+// @param {Number} $x
+// @example
+//     sqrt(2) // 1.41421
+//     sqrt(5) // 2.23607
+@function sqrt ($x) {
+    @if $x < 0 {
+        @warn "Argument for `sqrt()` must be a positive number.";
+        @return null;
+    }
+    $ret: 1;
+    @for $i from 1 through 24 {
+        $ret: $ret - ($ret * $ret - $x) / (2 * $ret);
+    }
+    @return $ret;
+}

--- a/src/scss/tools/_color.scss
+++ b/src/scss/tools/_color.scss
@@ -94,6 +94,8 @@
 	@return floor($number * $multiplier) / $multiplier;
 }
 
+// sass-lint:disable variable-name-format
+
 // Returns the square root of a number.
 // @param {Number} $x
 // @example
@@ -235,3 +237,4 @@ $SQRT2: 1.4142135623730951;
     }
     @return $x;
 }
+// sass-lint:enable variable-name-format

--- a/src/scss/tools/_color.scss
+++ b/src/scss/tools/_color.scss
@@ -195,3 +195,43 @@ $SQRT2: 1.4142135623730951;
     }
     @return 2 * $s;
 }
+
+// Returns a two-element list containing the normalized fraction and exponent of number.
+// @param {Number} $x
+// @return {List} fraction, exponent
+@function frexp ($x) {
+    $exp: 0;
+    @if $x < 0 {
+        $x: $x * -1;
+    }
+    @if $x < 0.5 {
+        @while $x < 0.5 {
+            $x: $x * 2;
+            $exp: $exp - 1;
+        }
+    } @else if $x >= 1 {
+        @while $x >= 1 {
+            $x: $x / 2;
+            $exp: $exp + 1;
+        }
+    }
+    @return $x, $exp;
+}
+
+// Returns $x * 2^$exp
+// @param {Number} $x
+// @param {Number} $exp
+@function ldexp ($x, $exp) {
+    $b: if($exp >= 0, 2, 1 / 2);
+    @if $exp < 0 {
+        $exp: $exp * -1;
+    }
+    @while $exp > 0 {
+        @if $exp % 2 == 1 {
+            $x: $x * $b;
+        }
+        $b: $b * $b;
+        $exp: floor($exp * 0.5);
+    }
+    @return $x;
+}


### PR DESCRIPTION
I'm not sure if we want to do this, feel free to ignore.

I was wondering if it would be possible to have Origami not depend on third-party dependencies and I came across o-colors depending on mathsass. This pull-request inlines the specific math functions we would require if we wanted to not depend on mathsass.

We could remove mathsass entirely if we dropped the contrast checking, which we have discussed before -- https://github.com/Financial-Times/o-colors/issues/192