### PR TITLE
Add focus outline colour.

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ This is a list of the use cases and their respective properties:
 
 `USECASE` | `PROPERTY` |
 ---|---
+focus |                 outline
 page |                  background
 box |                   background
 link |                  text

--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -55,7 +55,7 @@
 ///
 ///
 /// @param {String} $usecase
-/// @param {String} $property - 'text', 'background', 'border' or 'all'
+/// @param {String} $property - 'text', 'background', 'border', 'outline', or 'all'
 @function oColorsGetUseCase($usecase, $property) {
 	@if (not map-has-key($o-colors-usecases, $usecase)) {
 		@return null;

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -82,8 +82,13 @@
 
 		color: $useCaseTextColor;
 	}
+
 	@if ($propertyList == 'all' or index($propertyList, 'border')) {
 		border-color: oColorsGetColorFor($useCaseList, border, $options: $args);
+	}
+
+	@if ($propertyList == 'all' or index($propertyList, 'outline')) {
+		outline-color: oColorsGetColorFor($useCaseList, outline, $options: $args);
 	}
 }
 

--- a/src/scss/_use-cases.scss
+++ b/src/scss/_use-cases.scss
@@ -23,6 +23,7 @@
 $_o-colors-branded-usecases: (
 	'master': (
 	//	<use case>                <properties>
+		focus:                    (outline: 'oxford-80'),
 		page:                     (background: 'paper'),
 		box:                      (background: 'wheat'),
 		link:                     (text: 'teal'),
@@ -53,6 +54,7 @@ $_o-colors-branded-usecases: (
 	),
 	'internal': (
 	//	<use case>                <properties>
+		focus:                    (outline: 'black-50'),
 		page:                     (background: 'white'),
 		box:                      (background: 'slate-white-5'),
 		link:                     (text: 'teal'),

--- a/test/scss/_functions.test.scss
+++ b/test/scss/_functions.test.scss
@@ -44,6 +44,7 @@
 
 	@include describe('oColorsGetUseCase') {
 		@include it('returns the palette color name for a use case') {
+			@include assert-equal(oColorsGetUseCase(focus, outline), ('oxford-80'));
 			@include assert-equal(oColorsGetUseCase(page, background), ('paper'));
 			@include assert-equal(oColorsGetUseCase(box, background), ('wheat'));
 			@include assert-equal(oColorsGetUseCase(link, text), ('teal'));

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -84,6 +84,7 @@
 		@include test('outputs property declarations for all defined properties for a use case') {
 			@include oColorsSetUseCase(test-color, text, 'jade');
 			@include oColorsSetUseCase(test-color, background, 'wheat');
+			@include oColorsSetUseCase(test-color, outline, 'crimson');
 			@include assert() {
 				@include output($selector: false) {
 					.test-colors {
@@ -95,6 +96,7 @@
 					.test-colors {
 						background-color: #f2dfce;
 						color: #00994d;
+						outline-color: #cc0000;
 					}
 				};
 			};


### PR DESCRIPTION
We want to [brand o-normalise](https://github.com/Financial-Times/o-normalise/issues/35), making the focus colour differ per brand and [customisable](https://github.com/Financial-Times/o-normalise/issues/40). We already have such logic for sharing branded colours between components in o-colors, so rather than repeat it in o-normalise we can add a usecase in o-colors.

`$o-normalise-focus-color` will be removed in favour of `oColorsGetUseCase(focus, outline)`.

Previously we [backed away](https://github.com/Financial-Times/o-colors/pull/170) from this approach because it was easier to stick with the `o-normalise` variable. There was also some chat about a focus colour not being a state and not a "thing" (read element) which was nonsense from my previous self -- it's a clear usecase for a consistent colour, and usecases for hover states are already defined.