### PR TITLE
Implement oColorsGetPalette and related updates.

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -8,8 +8,8 @@ The following variables have changed:
 
 The following mixins have changed:
 
-- `oColorsGetPaletteColor` is now [`oColorsSetColor`](#oColorsSetColor).
-- [`oColorsByName`](#oColorsByName) has updated arguments.
+- `oColorsGetPaletteColor` is now [`oColorsByName`](#oColorsByName).
+- [`oColorsSetColor`](#oColorsSetColor) has updated arguments.
 
 The following have been removed from the palette:
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,6 +2,45 @@
 
 ### Upgrading from v4 to v5
 
+The following variables have changed:
+
+- `$o-colors-palette` has been removed. Use `oColorsSetColor` to add to the palette, `oColorsByName` to fetch colors from the palette, and `oColorsGetPalette` to iterate over the palette.
+
+The following mixins have changed:
+
+- `oColorsGetPaletteColor` is now [`oColorsSetColor`](#oColorsSetColor).
+- [`oColorsByName`](#oColorsByName) has updated arguments.
+
+The following have been removed from the palette:
+
+- `inherit`. Replace `oColorsByName('inherit');` with `inherit`.
+- `transparent`. Replace `oColorsByName('transparent');` with `transparent`.
+
+#### oColorsByName
+
+`oColorsGetPaletteColor` is now `oColorsByName`. The `$name` argument has been renamed `$color-name` and it must be of type string. A second argument `$from` may also be given to get a colour set by a component or project other than o-colors.
+
+To fetch a default `o-colors` colour.
+```diff
+-color: oColorsGetPaletteColor('paper');
++color: oColorsByName('paper');
+```
+
+To fetch a colour set by a component or project other that `o-colors`.
+```diff
+// Fetch the colour 'stormy' from the component 'o-example'.
+-color: oColorsGetPaletteColor('o-example-story');
++color: oColorsByName('stormy', 'o-example');
+```
+
+Or with argument names:
+```diff
+// Fetch the colour 'stormy' from the component 'o-example'.
+-color: oColorsGetPaletteColor($name: 'o-example-story');
++color: oColorsByName($color-name: 'stormy', $from: 'o-example');
+```
+
+
 #### oColorsSetColor
 
 The arguments of `oColorsSetColor` have changed. And it now supports a colour deprecation message.

--- a/README.md
+++ b/README.md
@@ -104,11 +104,11 @@ _This function will not generate a text color based on the use case like `oColor
 
 ### Palette color function
 
-If you have a color use case not covered by those built into the colors module, consider defining a custom use case (see below) and then using the use case mixin or function described above.  However, if you need to use a particular color in one single place only, it may be worth using the `oColorsGetPaletteColor` function, which returns the CSS color for a palette color name:
+If you have a color use case not covered by those built into the colors module, consider defining a custom use case (see below) and then using the use case mixin or function described above.  However, if you need to use a particular color in one single place only, it may be worth using the `oColorsByName` function, which returns the CSS color for a palette color name:
 
 ```scss
 .my-thing {
-	color: oColorsGetPaletteColor('white-60');
+	color: oColorsByName('white-60');
 }
 ```
 
@@ -122,7 +122,7 @@ Usage:
 
 ```scss
 .o-colors-palette-teal {
-	color: oColorsGetTextColor(oColorsGetPaletteColor('teal'), 80);
+	color: oColorsGetTextColor(oColorsByName('teal'), 80);
 }
 ```
 

--- a/demos/src/contrast-checker/contrast-checker.scss
+++ b/demos/src/contrast-checker/contrast-checker.scss
@@ -74,11 +74,11 @@ body {
 		[role=tab] {
 			color: black;
 			border-color: black;
-			background-color: oColorsGetPaletteColor('white');
+			background-color: oColorsByName('white');
 		}
 
 		[role=tab][aria-selected=true] {
-				background-color: oColorsGetPaletteColor('black-10');
+				background-color: oColorsByName('black-10');
 
 			a {
 				font-weight: 600;
@@ -92,9 +92,9 @@ body {
 
 	.swatches {
 		border-top: 0;
-		margin: 0; 
+		margin: 0;
 
-		span, 
+		span,
 		br {
 			margin-bottom: 6px;
 		}
@@ -180,7 +180,7 @@ body {
 	.rating-result {
 		&--aaa,
 		&--aa {
-			color: oColorsGetPaletteColor('jade');
+			color: oColorsByName('jade');
 		}
 
 		&--aa18 {
@@ -188,7 +188,7 @@ body {
 		}
 
 		&--fail {
-			color: oColorsGetPaletteColor('crimson');
+			color: oColorsByName('crimson');
 		}
 	}
 

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -15,22 +15,21 @@ body {
 	}
 }
 
-@each $name, $value in $o-colors-palette {
-	@if $name != 'transparent' and $name != 'inherit' {
-		.o-colors-border-#{$name} {
-			border-width: 2px 2px 0;
-			border-style: solid;
-			border-color:  oColorsGetPaletteColor($name);
+@each $color-details in oColorsGetPalette() {
+	$name: map-get($color-details, 'name');
+	.o-colors-border-#{$name} {
+		border-width: 2px 2px 0;
+		border-style: solid;
+		border-color:  oColorsByName($name);
 
-			@if $name == 'white' {
-				border-color: oColorsMix(black, white, 20);
-			}
+		@if $name == 'white' {
+			border-color: oColorsMix(black, white, 20);
 		}
+	}
 
 	.o-colors-palette-#{$name} .hex,
-		.o-colors-palette-#{$name}:after {
-			color: oColorsGetTextColor($name, 95);
-		}
+	.o-colors-palette-#{$name}:after {
+		color: oColorsGetTextColor($name, 95);
 	}
 }
 

--- a/main.scss
+++ b/main.scss
@@ -13,7 +13,8 @@
 @import 'src/scss/functions';
 @import 'src/scss/mixins';
 
-// Set the tint palette colors programatically
+// Set the palette colors programatically
+@include _oColorsSetPaletteColors;
 @include _oColorsSetPaletteTints;
 
 /// Output `o-colors` CSS classes and custom properties.
@@ -41,13 +42,13 @@
 			@each $prop, $color in $props {
 				#{'.o-colors-' + $usecase + '-' + $prop} {
 					@if $prop == text or $prop == all {
-						color: oColorsGetPaletteColor($color);
+						color: oColorsByName($color);
 					}
 					@if $prop == background or $prop == all {
-						background-color: oColorsGetPaletteColor($color);
+						background-color: oColorsByName($color);
 					}
 					@if $prop == border or $prop == all {
-						border-color: oColorsGetPaletteColor($color);
+						border-color: oColorsByName($color);
 					}
 				}
 			}
@@ -55,9 +56,10 @@
 	}
 
 	@if($palette-classes) {
-		@each $name, $value in $o-colors-palette {
+		@each $color-details in oColorsGetPalette() {
+			$name: map-get($color-details, 'name');
 			.o-colors-palette-#{$name} {
-				background-color: oColorsGetPaletteColor($name);
+				background-color: oColorsByName($name);
 
 				@if $name != 'transparent' and $name != 'inherit' {
 					color: oColorsGetTextColor($name, 100, $warnings: false);

--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -3,33 +3,59 @@
 /// @link http://registry.origami.ft.com/components/o-colors
 ////
 
-/// Return the CSS color for a palette color name
+/// Return the CSS color for a palette color name.
 ///
-/// @param {String|Color|Null} $name
-@function oColorsGetPaletteColor($name) {
-	// Due to an apparent bug in dart-sass we can't use `inspect` with a string to get values from a map.
-	// When compiled by dart-sass: inspect("string") != "string"
-	// https://github.com/sass/dart-sass/issues/594
-	$name-string: if(type-of($name) == 'string', $name, inspect($name));
-	@if (map-has-key($o-colors-palette, $name-string)) {
-		$color: map-get($o-colors-palette, $name-string);
-
-		//check if it is deprecated
-		@if type-of($color) == list {
-			@if nth($color, 2) == '_deprecated' and $_o-colors-deprecated-palette-color-warnings {
-				@warn "#{$name} is deprecated for the #{$_o-colors-brand} palette, and will be removed in the next major.";
-			}
-
-			$color: nth($color, 1);
-		}
-
-		@return $color;
-	} @else if $name != null and type-of($name) != color {
-		@warn "Color name '#{$name-string}' is not defined in the palette.";
-		@return null;
-	} @else {
-		@return $name;
+/// @param {String} $color-name - The name of the colour to get.
+/// @param {String} $from ['o-colors'] - Which component or project to get the colour from (optional).
+@function oColorsByName($color-name, $from: 'o-colors') {
+	// Validate arguments are strings.
+	@if(type-of($color-name) != 'string') {
+		@return _error('`$color-name` should be a string but found "#{inspect($color-name)}" of type "#{type-of($color-name)}".');
 	}
+	@if(type-of($from) != 'string') {
+		@return _error('`$from` should be a string but found "#{inspect($from)}" of type "#{type-of($from)}".');
+	}
+	// Error when the color name is not found.
+	// Get the namespaced color name.
+	$namespaced-color-name: '#{$from}-#{$color-name}';
+	$color-map: map-get($_o-colors-palette, $namespaced-color-name);
+	@if (not $color-map) {
+		@return _error('The color "#{inspect($color-name)}" set by "#{inspect($from)}" does not exist.');
+	}
+
+	// Get color details.
+	$color: map-get($color-map, 'color');
+	$meta: map-get($color-map, 'meta');
+
+	// Output any deprecation notice.
+	$deprecated: map-get($meta, 'deprecated');
+	$already-warned: index($_o-colors-deprecation-warnings-output, $namespaced-color-name) != null;
+	@if $deprecated and not $already-warned {
+		$deprecation-message: 'The color "#{$color-name}" from "#{$from}" is deprecated for the "#{$_o-colors-brand}" palette, and will be removed in the next major.';
+		// Append any custom deprecation message.
+		$deprecation-message: if(type-of($deprecated) != 'string', $deprecation-message, $deprecation-message + ' ' + $deprecated);
+		// Output warning.
+		$_o-colors-deprecation-warnings-output: append($_o-colors-deprecation-warnings-output, $namespaced-color-name) !global;
+		@warn $deprecation-message;
+	}
+
+	@return $color;
+}
+
+/// Return color names and the component/project name they're from.
+/// @return {List} - A list of maps with palette color details e.g. `(('name': 'paper', 'from': 'o-colors'), ('name': 'storm', 'from': 'o-example'))`
+@function oColorsGetPalette() {
+	$public-palette-details: ();
+
+	@each $name, $color-map in $_o-colors-palette {
+		$details: (
+			'name': map-get($color-map, 'name'),
+			'from': map-get($color-map, 'from')
+		);
+		$public-palette-details: append($public-palette-details, $details);
+	}
+
+	@return $public-palette-details;
 }
 
 /// Returns a color based on the background context and base color
@@ -39,8 +65,8 @@
 /// @param {String} $color [black] - palette name of color
 /// @param {Number} $percentage [60] - percentage opacity of the color over the background
 @function oColorsMix($color: 'black', $background: oColorsGetUseCase('page', 'background'), $percentage: 80) {
-	$base: oColorsGetPaletteColor($background);
-	$mixer: oColorsGetPaletteColor($color);
+	$base: if(type-of($background) == 'string', oColorsByName($background), $background);
+	$mixer: if(type-of($color) == 'string', oColorsByName($color), $color);
 
 	@if type-of($base) != color {
 		@return _error("'#{inspect($background)}' is not a valid base color.");
@@ -95,7 +121,7 @@
 ///
 /// @param {list} $namelist
 /// @param {String} $property [all]
-/// @param {map} $options [('default': false)] - default: fallback value (false, null, or oColorsGetPaletteColor($palette-color));
+/// @param {map} $options [('default': false)] - default: fallback value (false, null, or oColorsByName($palette-color));
 /// @return {String|Color|Null}
 @function oColorsGetColorFor($namelist, $property: all, $options: ('default': false)) {
 	$default: map-get($options, 'default');
@@ -119,7 +145,7 @@
 		@warn $warn;
 	}
 
-	@return oColorsGetPaletteColor($color);
+	@return oColorsByName($color);
 }
 
 /// Returns a customised version of our shade-able colors defined in
@@ -156,7 +182,7 @@
 /// @param {Number} $opacity [100] - the opacity percentage the text color should appear at
 /// @param {Boolean} $warnings [true] - whether this function should throw WCAG contrast check warnings/errors
 @function oColorsGetTextColor($backgroundd, $opacity: 90, $warnings: true) {
-	$background: oColorsGetPaletteColor($backgroundd);
+	$background: if(type-of($backgroundd) == 'string', oColorsByName($backgroundd), $backgroundd);
 
 	@if $background == null or type-of($background) != color {
 		@return _error("'#{inspect($background)}' is not a valid color. To get a text color, please supply a valid hex code or color name for the background color'");

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -1,7 +1,5 @@
 /// Define a new palette color.
 ///
-/// @todo Pre-major cascade: Refactor to support deprecated messages, the same as use-cases.
-///
 /// @example scss - Add a custom palette color
 ///     @include oColorsSetColor($project-name: 'o-example', $color-name: 'pink', $color-hex: #ff69b4);
 ///
@@ -18,7 +16,7 @@
 /// @param {Color} $color-hex - The colour to set (hex) e.g. #ff69b4.
 /// @param {Map} $opts - A map of options. Accepts a `deprecated` key with a message to deprecated a set colour e.g. `$opts: (deprecated: 'your deprecation message')`.
 @mixin oColorsSetColor($project-name, $color-name, $color-hex, $opts: ()) {
-	// Validate arguments.
+	// Validate arguments are of correct type.
 	$missing-namespace: type-of($project-name) != 'string';
 	$missing-color-name: type-of($color-name) != 'string';
 	$missing-color-hex: type-of($color-hex) != 'color';
@@ -26,21 +24,19 @@
 		@error 'Expected a string `$project-name` and `$color-name` to set a new colour.';
 	}
 	@if $missing-color-hex {
-		@error 'Expected `$color-hex ` to be a colour, found type "#{type-of($color)}".';
+		@error 'Expected `$color-hex ` to be a colour, found "#{$color-hex}" of type "#{type-of($color-hex)}".';
 	}
 	// Get the namespaced color name.
 	$namespaced-color-name: '#{$project-name}-#{$color-name}';
-	// If a deprecation message has been given, mark the colour as deprecated.
-	// o-colors currently identified deprecated palette colours by assigning
-	// a color name to a list with the colour hex and `_deprecated`.
-	// @todo refactor to support deprecated messages the same as use-cases.
-	$deprecation-message: map-get($opts, 'deprecated');
-	@if($deprecation-message) {
-		$color-hex: $namespaced-color-name, '_deprecated';
-	}
 	// Set the new colour to the colour palette.
-	$new-color: ($namespaced-color-name: $color-hex);
-	$o-colors-palette: map-merge($o-colors-palette, $new-color) !global;
+	$deprecation-message: map-get($opts, 'deprecated');
+	$new-color: ($namespaced-color-name: (
+		'color': $color-hex,
+		'name': $color-name,
+		'$from': $project-name,
+		'meta': ('deprecated': $deprecation-message)
+	));
+	$_o-colors-palette: map-merge($_o-colors-palette, $new-color) !global;
 };
 
 /// Add a custom use case property
@@ -50,7 +46,7 @@
 ///
 /// @param {String} $usecase - Name of the use case
 /// @param {String} $property - Property it applies to
-/// @param {String} $color - One of $o-colors-palette
+/// @param {String} $color - One of $_o-colors-palette
 @mixin oColorsSetUseCase($usecase, $property, $color) {
 	$propmap: ($property: $color);
 
@@ -111,7 +107,6 @@
 	}
 }
 
-/// @todo Pre-major cascade: Use `oColorsSetColor` to set namespaced tints.
 /// Update the palette with calculated tints of
 /// each color from $o-colors-tints
 @mixin _oColorsSetPaletteTints {
@@ -126,9 +121,7 @@
 			$saturation: map-get($settings, 'saturation');
 		}
 
-		@if map-has-key($settings, '_deprecated') {
-			$deprecated: '_deprecated';
-		}
+		$deprecated:  map-has-key($settings, '_deprecated');
 
 		@if $tints != null {
 			@each $value in $tints {
@@ -142,18 +135,29 @@
 				}
 
 				// @todo use oColorsSetColor
-				$new-tine: ($name: ($tint, $deprecated));
-				$o-colors-palette: map-merge($o-colors-palette, $new-tine) !global;
+				@include oColorsSetColor('o-colors', $name, $tint, $opts: (
+					'deprecated': $deprecated
+				));
 			}
 		}
+	}
+}
+
+/// Update the palette with default o-colors palette colours.
+@mixin _oColorsSetPaletteColors {
+	@each $color-name, $color-details in $_o-colors-default-palette-colors {
+		$color-hex: map-get($color-details, 'color');
+		$opts: map-get($color-details, 'opts');
+		@include oColorsSetColor('o-colors', $color-name, $color-hex, $opts);
 	}
 }
 
 /// Output all palette colors as CSS Variables
 @mixin _oColorsCSSVariables {
 	:root {
-		@each $name, $hex in $o-colors-palette {
-			#{--o-colors-}#{$name}: oColorsGetPaletteColor($name);
+		@each $color-map in oColorsGetPalette() {
+			$name: map-get($color-map, 'name');
+			#{--o-colors-}#{$name}: oColorsByName($name);
 		}
 	}
 }

--- a/src/scss/_palette.scss
+++ b/src/scss/_palette.scss
@@ -1,133 +1,106 @@
-////
-/// @group o-colors
-/// @link http://registry.origami.ft.com/components/o-colors
-////
+// Define universal primary palette.
+$_o-colors-default-palette-colors: map-merge((
+	'black':                 ('color': #000000, 'opts': ()),
+	'white':                 ('color': #ffffff, 'opts': ()),
+), $_o-colors-default-palette-colors);
 
-/// color palette
-///
-/// These are the colors that make up the FT palette.
-/// We don't use these colors directly, but instead assign them to 'use cases',
-/// which are defined in use-cases.scss.
-///
-/// In the list below, each line contains a color name and a color code,
-/// and is finished with a comma:
-///
-/// 	<color name>:   <color code>,
-///
-/// The color name must be a single word comprising just letters,
-/// numbers, and dashes.
-///
-/// You can have as many spaces between the color name and the color code
-/// as you like (so you can line them up neatly), and you *MUST* finish the
-/// line with a comma.
-///
-/// @type map
-
-$o-colors-palette: map-merge((
-// non-color css values
-'transparent':           transparent,
-'inherit':               inherit,
-
-// primary palette
-'black':                 #000000,
-'white':                 #ffffff,
-), $o-colors-palette);
-
-/// Brand to define conditionally
-///
-/// @type String
-$_o-colors-brand: oBrandGetCurrentBrand();
-
+// Master brand palette.
 @if $_o-colors-brand == master {
-	$o-colors-palette: map-merge((
+	$_o-colors-default-palette-colors: map-merge((
 		// primary palette
-		'paper':                 #fff1e5,
-		'claret':                #990f3d,
-		'oxford':                #0f5499,
-		'teal':                  #0d7680,
+		'paper':                 ('color': #fff1e5, 'opts': ()),
+		'claret':                ('color': #990f3d, 'opts': ()),
+		'oxford':                ('color': #0f5499, 'opts': ()),
+		'teal':                  ('color': #0d7680, 'opts': ()),
 
 		//secondary palette
-		'wheat':                 #f2dfce,
-		'sky':                   #cce6ff,
-		'slate':                 #262a33,
-		'velvet':                #593380,
-		'mandarin':              #ff8833,
-		'lemon':                 #ffec1a,
+		'wheat':                 ('color': #f2dfce, 'opts': ()),
+		'sky':                   ('color': #cce6ff, 'opts': ()),
+		'slate':                 ('color': #262a33, 'opts': ()),
+		'velvet':                ('color': #593380, 'opts': ()),
+		'mandarin':              ('color': #ff8833, 'opts': ()),
+		'lemon':                 ('color': #ffec1a, 'opts': ()),
 
 		//tertiary palette
-		'candy':                 #ff7faa,
-		'wasabi':                #96cc28,
-		'jade':                  #00994d,
-		'crimson':               #cc0000,
+		'candy':                 ('color': #ff7faa, 'opts': ()),
+		'wasabi':                ('color': #96cc28, 'opts': ()),
+		'jade':                  ('color': #00994d, 'opts': ()),
+		'crimson':               ('color': #cc0000, 'opts': ()),
 
 		//b2c palette
-		'org-b2c':               #4e96eb,
-		'org-b2c-dark':          #3a70af,
-		'org-b2c-light':         #99c6fb,
-	), $o-colors-palette);
+		'org-b2c':               ('color': #4e96eb, 'opts': ()),
+		'org-b2c-dark':          ('color': #3a70af, 'opts': ()),
+		'org-b2c-light':         ('color': #99c6fb, 'opts': ()),
+	), $_o-colors-default-palette-colors);
 }
 
+// Internal brand palette.
 @if $_o-colors-brand == internal {
-	$o-colors-palette: map-merge((
-	// primary palette
-	'oxford':          #0f5499,
-	'teal':            #0d7680,
-	'paper':          (#fff1e5, '_deprecated'),
-	'claret':         (#990f3d, '_deprecated'),
+	$_o-colors-default-palette-colors: map-merge((
+		// primary palette
+		'oxford':         ('color': #0f5499, 'opts': ()),
+		'teal':           ('color': #0d7680, 'opts': ()),
+		'paper':          ('color': #fff1e5, 'opts': ('deprecated': true)),
+		'claret':         ('color': #990f3d, 'opts': ('deprecated': true)),
 
-	//secondary palette
-	'lemon':           #ffec1a,
-	'slate':           #262a33,
-	'wheat':          (#f2dfce, '_deprecated'),
-	'sky':            (#cce6ff, '_deprecated'),
-	'velvet':         (#593380, '_deprecated'),
-	'mandarin':       (#ff8833, '_deprecated'),
+		//secondary palette
+		'lemon':          ('color': #ffec1a, 'opts': ()),
+		'slate':          ('color': #262a33, 'opts': ()),
+		'wheat':          ('color': #f2dfce, 'opts': ('deprecated': true)),
+		'sky':            ('color': #cce6ff, 'opts': ('deprecated': true)),
+		'velvet':         ('color': #593380, 'opts': ('deprecated': true)),
+		'mandarin':       ('color': #ff8833, 'opts': ('deprecated': true)),
 
-	//tertiary palette
-	'jade':            #00994d,
-	'crimson':         #cc0000,
-	'candy':          (#ff7faa, '_deprecated'),
-	'wasabi':         (#96cc28, '_deprecated'),
+		//tertiary palette
+		'jade':           ('color': #00994d, 'opts': ()),
+		'crimson':        ('color': #cc0000, 'opts': ()),
+		'candy':          ('color': #ff7faa, 'opts': ('deprecated': true)),
+		'wasabi':         ('color': #96cc28, 'opts': ('deprecated': true)),
 
-	//b2c palette
-	'org-b2c':        (#4e96eb, '_deprecated'),
-	'org-b2c-dark':   (#3a70af, '_deprecated'),
-	'org-b2c-light':  (#99c6fb, '_deprecated'),
-	), $o-colors-palette);
+		//b2c palette
+		'org-b2c':        ('color': #4e96eb, 'opts': ('deprecated': true)),
+		'org-b2c-dark':   ('color': #3a70af, 'opts': ('deprecated': true)),
+		'org-b2c-light':  ('color': #99c6fb, 'opts': ('deprecated': true)),
+	), $_o-colors-default-palette-colors);
 
 	// Add experimental colors to support work on the internal brand design.
-	$o-colors-palette: map-merge($_o-colors-experimental-internal-palette, $o-colors-palette);
+	$_o-colors-default-palette-colors: map-merge((
+		'slate-white-15': ('color': #dedfe0, 'opts': ()), // oColorsMix('slate', 'white', 15): to support work on internal brand design
+		'slate-white-5':  ('color': #f4f4f5, 'opts': ()), // oColorsMix('slate', 'white', 5): to support work on internal brand design
+	), $_o-colors-default-palette-colors);
 }
 
+// Whitelabel brand palette.
 @if $_o-colors-brand == whitelabel {
-	$o-colors-palette: map-merge((
-	// primary palette
-	'oxford':         (#0f5499, '_deprecated'),
-	'teal':           (#0d7680, '_deprecated'),
-	'paper':          (#fff1e5, '_deprecated'),
-	'claret':         (#990f3d, '_deprecated'),
+	$_o-colors-default-palette-colors: map-merge((
+		// primary palette
+		'oxford':         ('color': #0f5499, 'opts': ('deprecated': true)),
+		'teal':           ('color': #0d7680, 'opts': ('deprecated': true)),
+		'paper':          ('color': #fff1e5, 'opts': ('deprecated': true)),
+		'claret':         ('color': #990f3d, 'opts': ('deprecated': true)),
 
-	//secondary palette
-	'lemon':          (#ffec1a, '_deprecated'),
-	'slate':          (#262a33, '_deprecated'),
-	'wheat':          (#f2dfce, '_deprecated'),
-	'sky':            (#cce6ff, '_deprecated'),
-	'velvet':         (#593380, '_deprecated'),
-	'mandarin':       (#ff8833, '_deprecated'),
+		//secondary palette
+		'lemon':          ('color': #ffec1a, 'opts': ('deprecated': true)),
+		'slate':          ('color': #262a33, 'opts': ('deprecated': true)),
+		'wheat':          ('color': #f2dfce, 'opts': ('deprecated': true)),
+		'sky':            ('color': #cce6ff, 'opts': ('deprecated': true)),
+		'velvet':         ('color': #593380, 'opts': ('deprecated': true)),
+		'mandarin':       ('color': #ff8833, 'opts': ('deprecated': true)),
 
-	//tertiary palette
-	'jade':           (#00994d, '_deprecated'),
-	'crimson':        (#cc0000, '_deprecated'),
-	'candy':          (#ff7faa, '_deprecated'),
-	'wasabi':         (#96cc28, '_deprecated'),
+		//tertiary palette
+		'jade':           ('color': #00994d, 'opts': ('deprecated': true)),
+		'crimson':        ('color': #cc0000, 'opts': ('deprecated': true)),
+		'candy':          ('color': #ff7faa, 'opts': ('deprecated': true)),
+		'wasabi':         ('color': #96cc28, 'opts': ('deprecated': true)),
 
-	//b2c palette
-	'org-b2c':        (#4e96eb, '_deprecated'),
-	'org-b2c-dark':   (#3a70af, '_deprecated'),
-	'org-b2c-light':  (#99c6fb, '_deprecated'),
-	), $o-colors-palette);
+		//b2c palette
+		'org-b2c':        ('color': #4e96eb, 'opts': ('deprecated': true)),
+		'org-b2c-dark':   ('color': #3a70af, 'opts': ('deprecated': true)),
+		'org-b2c-light':  ('color': #99c6fb, 'opts': ('deprecated': true)),
+	), $_o-colors-default-palette-colors);
 }
 
+// Master brand palette tints.
 @if $_o-colors-brand == master {
 	$o-colors-tints: map-merge((
 		'black': (
@@ -193,6 +166,8 @@ $_o-colors-brand: oBrandGetCurrentBrand();
 		)
 	), $o-colors-tints);
 }
+
+// Internal brand palette tints.
 @if $_o-colors-brand == internal {
 	$o-colors-tints: map-merge((
 		'black': (
@@ -265,6 +240,8 @@ $_o-colors-brand: oBrandGetCurrentBrand();
 		),
 	), $o-colors-tints);
 }
+
+// Whitelabel brand palette tints.
 @if $_o-colors-brand == whitelabel {
 	$o-colors-tints: map-merge((
 		'black': (

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -1,12 +1,20 @@
 $o-colors-is-silent: true !default;
 
-$o-colors-palette: () !default;
-$o-colors-tints: () !default;
+/// Brand to define colours conditionally.
+///
+/// @type String
+$_o-colors-brand: oBrandGetCurrentBrand();
 
-$_o-colors-experimental-internal-palette: (
-	'slate-white-15':        #dedfe0, // oColorsMix('slate', 'white', 15): to support work on internal brand design
-	'slate-white-5':         #f4f4f5, // oColorsMix('slate', 'white', 5): to support work on internal brand design
-);
+/// Default FT colours to add to the colour palette.
+/// @prop {Map}
+/// @prop {Map} base.color-name - Where `color-name` is the name of the colour, e.g. paper.
+/// @prop {Color} base.color-name.color - The color for the colour name.
+/// @prop {Map} base.color-name.opts - Extra details about the colour.
+/// @prop {String|Boolean} base.color-name.opts.deprecated - True, or a deprecation message, if the colour is deprecated.
+$_o-colors-default-palette-colors: () !default;
+
+$_o-colors-palette: () !default;
+$o-colors-tints: ();
 
 $o-colors-usecases: () !default;
 
@@ -14,11 +22,6 @@ $o-colors-usecases: () !default;
 // When the usecase is used and `null` is returned, there is no need to warn about it.
 // Warning is still useful in other cases to highlight misspelled usecases, or missing custom usecases.
 $_o-colors-ignore-usecases-warnings: ('page', 'box', 'link', 'link-hover', 'link-title', 'link-title-hover', 'title', 'body', 'muted');
-
-// Whether to show deprecated palette color warnings.
-// v4 of o-colors has many deprecations for the internal and whtielabel brands.
-// These still effect our components, so users are spammed with warnings they cannot solve.
-// So suppress these warnings. The deprecated colors will be removed in the next major.
-$_o-colors-deprecated-palette-color-warnings: oBrandGetCurrentBrand() == 'master' !default;
+$_o-colors-deprecation-warnings-output: ();
 
 $_o-colors-test-environment: false !default;

--- a/test/scss/_functions.test.scss
+++ b/test/scss/_functions.test.scss
@@ -1,32 +1,32 @@
 @include describe('oColors functions') {
-	@include describe('oColorsGetPaletteColor') {
+	@include describe('oColorsByName') {
 		@include it('returns a CSS color for a palette color name, given as a string') {
-			@include assert-equal(oColorsGetPaletteColor('transparent'), (transparent));
-			@include assert-equal(oColorsGetPaletteColor('inherit'), (inherit));
-			@include assert-equal(oColorsGetPaletteColor('paper'), (#fff1e5));
-			@include assert-equal(oColorsGetPaletteColor('black'), (#000000));
-			@include assert-equal(oColorsGetPaletteColor('white'), (#ffffff));
-			@include assert-equal(oColorsGetPaletteColor('claret'), (#990f3d));
-			@include assert-equal(oColorsGetPaletteColor('oxford'), (#0f5499));
-			@include assert-equal(oColorsGetPaletteColor('teal'), (#0d7680));
-			@include assert-equal(oColorsGetPaletteColor('wheat'), (#f2dfce));
-			@include assert-equal(oColorsGetPaletteColor('sky'), (#cce6ff));
-			@include assert-equal(oColorsGetPaletteColor('velvet'), (#593380));
-			@include assert-equal(oColorsGetPaletteColor('mandarin'), (#ff8833));
-			@include assert-equal(oColorsGetPaletteColor('lemon'), (#ffec1a));
-			@include assert-equal(oColorsGetPaletteColor('candy'), (#ff7faa));
-			@include assert-equal(oColorsGetPaletteColor('wasabi'), (#96cc28));
-			@include assert-equal(oColorsGetPaletteColor('jade'), (#00994d));
-			@include assert-equal(oColorsGetPaletteColor('crimson'), (#cc0000));
-			@include assert-equal(oColorsGetPaletteColor('org-b2c'), (#4e96eb));
-			@include assert-equal(oColorsGetPaletteColor('org-b2c-dark'), (#3a70af));
-			@include assert-equal(oColorsGetPaletteColor('org-b2c-light'), (#99c6fb));
+			@include assert-equal(oColorsByName('paper'), (#fff1e5));
+			@include assert-equal(oColorsByName('black'), (#000000));
+			@include assert-equal(oColorsByName('white'), (#ffffff));
+			@include assert-equal(oColorsByName('claret'), (#990f3d));
+			@include assert-equal(oColorsByName('oxford'), (#0f5499));
+			@include assert-equal(oColorsByName('teal'), (#0d7680));
+			@include assert-equal(oColorsByName('wheat'), (#f2dfce));
+			@include assert-equal(oColorsByName('sky'), (#cce6ff));
+			@include assert-equal(oColorsByName('velvet'), (#593380));
+			@include assert-equal(oColorsByName('mandarin'), (#ff8833));
+			@include assert-equal(oColorsByName('lemon'), (#ffec1a));
+			@include assert-equal(oColorsByName('candy'), (#ff7faa));
+			@include assert-equal(oColorsByName('wasabi'), (#96cc28));
+			@include assert-equal(oColorsByName('jade'), (#00994d));
+			@include assert-equal(oColorsByName('crimson'), (#cc0000));
+			@include assert-equal(oColorsByName('org-b2c'), (#4e96eb));
+			@include assert-equal(oColorsByName('org-b2c-dark'), (#3a70af));
+			@include assert-equal(oColorsByName('org-b2c-light'), (#99c6fb));
 		};
-		@include it('returns a CSS color for a palette color name, given as a color') {
-			@include assert-equal(oColorsGetPaletteColor(transparent), (transparent));
-			@include assert-equal(oColorsGetPaletteColor(inherit), (inherit));
-			@include assert-equal(oColorsGetPaletteColor(black), (#000000));
-			@include assert-equal(oColorsGetPaletteColor(white), (#ffffff));
+		@include it('returns an error if `$color-name` is not a string') {
+			@include assert-equal(oColorsByName(null),
+			('ERROR: `$color-name` should be a string but found "null" of type "null".'));
+		};
+		@include it('returns an error if the `$from` argument is not a string') {
+			@include assert-equal(oColorsByName('candy', null),
+			('ERROR: `$from` should be a string but found "null" of type "null".'));
 		};
 	};
 
@@ -89,8 +89,8 @@
 
 			@include it('and assigns a fallback in case of non existent use case') {
 				@include assert-equal(
-				oColorsGetColorFor(test-link, text, $options: ('default': oColorsGetPaletteColor('teal-20'))),
-				(oColorsGetPaletteColor('teal-20')));
+				oColorsGetColorFor(test-link, text, $options: ('default': oColorsByName('teal-20'))),
+				(oColorsByName('teal-20')));
 			};
 		};
 	};
@@ -108,14 +108,14 @@
 
 	@include describe('oColorsGetTextColor') {
 		@include it('returns a text color based on background and opacity percentage') {
-			@include assert-equal(oColorsGetTextColor(oColorsGetPaletteColor('paper')), (#1a1817));
+			@include assert-equal(oColorsGetTextColor(oColorsByName('paper')), (#1a1817));
 		};
 		@include it('throws an error if a text color and background does not pass WCAG contrast guidelines') {
-			@include assert-equal(oColorsGetTextColor(oColorsGetPaletteColor('black-40'), 50),
+			@include assert-equal(oColorsGetTextColor(oColorsByName('black-40'), 50),
 			('ERROR: The combination of 50% black on #999189 does not pass WCAG guidelines for color contrast.'));
 		};
 		@include it('does not throw an error when a text color and background does not pass WCAG contrast guidelines and warnings are disabled') {
-			@include assert-equal(oColorsGetTextColor(oColorsGetPaletteColor('black-40'), 50, $warnings: false),  #4d4945);
+			@include assert-equal(oColorsGetTextColor(oColorsByName('black-40'), 50, $warnings: false),  #4d4945);
 		};
 	};
 };

--- a/test/scss/_internal.test.scss
+++ b/test/scss/_internal.test.scss
@@ -4,18 +4,18 @@ $o-brand: 'internal';
 @include describe('branded palettes') {
 	@include describe('internal') {
 		@include test('has shared colours') {
-			@include assert-equal(oColorsGetPaletteColor('black'), (#000000));
-			@include assert-equal(oColorsGetPaletteColor('white'), (#ffffff));
+			@include assert-equal(oColorsByName('black'), (#000000));
+			@include assert-equal(oColorsByName('white'), (#ffffff));
 		};
 
 		@include test('does have deprecated masterbrand colors') {
-			@include assert-equal(oColorsGetPaletteColor('paper'), (#fff1e5));
-			@include assert-equal(oColorsGetPaletteColor('claret'), (#990f3d));
-			@include assert-equal(oColorsGetPaletteColor('wheat'), (#f2dfce));
-			@include assert-equal(oColorsGetPaletteColor('sky'), (#cce6ff));
-			@include assert-equal(oColorsGetPaletteColor('org-b2c'), (#4e96eb));
-			@include assert-equal(oColorsGetPaletteColor('org-b2c-dark'), (#3a70af));
-			@include assert-equal(oColorsGetPaletteColor('org-b2c-light'), (#99c6fb));
+			@include assert-equal(oColorsByName('paper'), (#fff1e5));
+			@include assert-equal(oColorsByName('claret'), (#990f3d));
+			@include assert-equal(oColorsByName('wheat'), (#f2dfce));
+			@include assert-equal(oColorsByName('sky'), (#cce6ff));
+			@include assert-equal(oColorsByName('org-b2c'), (#4e96eb));
+			@include assert-equal(oColorsByName('org-b2c-dark'), (#3a70af));
+			@include assert-equal(oColorsByName('org-b2c-light'), (#99c6fb));
 		};
 	};
 }

--- a/test/scss/_master.test.scss
+++ b/test/scss/_master.test.scss
@@ -1,19 +1,3 @@
-// to change the brand in the testing environement, we need to reset the variables
-$o-colors-is-silent: true !global;
-
-$_o-colors-brand: if(global-variable-exists(o-brand), if($o-brand != null, $o-brand, 'master'), 'master');
-
-$o-colors-palette: () !global;
-$o-colors-tints: () !global;
-
-$_o-colors-experimental-internal-palette: (
-	'slate-white-15':        #dedfe0, // oColorsMix('slate', 'white', 15): to support work on internal brand design
-	'slate-white-5':         #f4f4f5, // oColorsMix('slate', 'white', 5): to support work on internal brand design
-);
-
-$o-colors-usecases: () !global;
-
-$o-brand: 'master';
 @import '../../main';
 
 @import 'tools/a11y.test';
@@ -26,18 +10,18 @@ $o-brand: 'master';
 @include describe('branded palettes') {
 	@include describe('master') {
 		@include test('has shared colours') {
-			@include assert-equal(oColorsGetPaletteColor('black'), (#000000));
-			@include assert-equal(oColorsGetPaletteColor('white'), (#ffffff));
+			@include assert-equal(oColorsByName('black'), (#000000));
+			@include assert-equal(oColorsByName('white'), (#ffffff));
 		};
 
 		@include test('has masterbrand colors') {
-			@include assert-equal(oColorsGetPaletteColor('paper'), (#fff1e5));
-			@include assert-equal(oColorsGetPaletteColor('claret'), (#990f3d));
-			@include assert-equal(oColorsGetPaletteColor('wheat'), (#f2dfce));
-			@include assert-equal(oColorsGetPaletteColor('sky'), (#cce6ff));
-			@include assert-equal(oColorsGetPaletteColor('org-b2c'), (#4e96eb));
-			@include assert-equal(oColorsGetPaletteColor('org-b2c-dark'), (#3a70af));
-			@include assert-equal(oColorsGetPaletteColor('org-b2c-light'), (#99c6fb));
+			@include assert-equal(oColorsByName('paper'), (#fff1e5));
+			@include assert-equal(oColorsByName('claret'), (#990f3d));
+			@include assert-equal(oColorsByName('wheat'), (#f2dfce));
+			@include assert-equal(oColorsByName('sky'), (#cce6ff));
+			@include assert-equal(oColorsByName('org-b2c'), (#4e96eb));
+			@include assert-equal(oColorsByName('org-b2c-dark'), (#3a70af));
+			@include assert-equal(oColorsByName('org-b2c-light'), (#99c6fb));
 		};
 	};
 }

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -69,7 +69,7 @@
 	@include describe('oColorsSetColor') {
 		@include it('adds a custom palette color') {
 			@include oColorsSetColor('o-colors', 'olive', #808000);
-			@include assert-equal(oColorsGetPaletteColor('o-colors-olive'), (#808000))
+			@include assert-equal(oColorsByName('olive'), (#808000))
 		};
 	};
 

--- a/test/scss/_palette.test.scss
+++ b/test/scss/_palette.test.scss
@@ -1,95 +1,95 @@
 @include describe('verify accesibility of core palette colours') {
 	@include describe('PASS') {
 		@include test('$color on #ffffff (white)') {
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('black'), #ffffff), ('AAA'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('claret'), #ffffff), ('AAA'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('oxford'), #ffffff), ('AAA'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('teal'), #ffffff), ('AA'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('slate'), #ffffff), ('AAA'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('velvet'), #ffffff), ('AAA'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('jade'), #ffffff), ('AA18'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('crimson'), #ffffff), ('AA'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('org-b2c'), #ffffff), ('AA18'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('org-b2c-dark'), #ffffff), ('AA'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('black'), #ffffff), ('AAA'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('claret'), #ffffff), ('AAA'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('oxford'), #ffffff), ('AAA'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('teal'), #ffffff), ('AA'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('slate'), #ffffff), ('AAA'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('velvet'), #ffffff), ('AAA'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('jade'), #ffffff), ('AA18'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('crimson'), #ffffff), ('AA'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('org-b2c'), #ffffff), ('AA18'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('org-b2c-dark'), #ffffff), ('AA'));
 		};
 
 		@include test('$color on #fff1e5 (paper)') {
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('black'), #fff1e5), ('AAA'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('claret'), #fff1e5), ('AAA'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('oxford'), #fff1e5), ('AA'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('teal'), #fff1e5), ('AA'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('slate'), #fff1e5), ('AAA'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('velvet'), #fff1e5), ('AAA'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('jade'), #fff1e5), ('AA18'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('crimson'), #fff1e5), ('AA'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('org-b2c'), #ffffff), ('AA18'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('org-b2c-dark'), #ffffff), ('AA'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('black'), #fff1e5), ('AAA'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('claret'), #fff1e5), ('AAA'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('oxford'), #fff1e5), ('AA'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('teal'), #fff1e5), ('AA'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('slate'), #fff1e5), ('AAA'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('velvet'), #fff1e5), ('AAA'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('jade'), #fff1e5), ('AA18'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('crimson'), #fff1e5), ('AA'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('org-b2c'), #ffffff), ('AA18'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('org-b2c-dark'), #ffffff), ('AA'));
 		};
 
 		@include test('$color on #000000 (black)') {
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('org-b2c-light'), #000000), ('AAA'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('paper'), #000000), ('AAA'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('wheat'), #000000), ('AAA'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('sky'), #000000), ('AAA'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('mandarin'), #000000), ('AAA'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('lemon'), #000000), ('AAA'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('candy'), #000000), ('AAA'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('wasabi'), #000000), ('AAA'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('white'), #000000), ('AAA'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('teal'), #000000), ('AA18'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('crimson'), #000000), ('AA18'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('org-b2c-light'), #000000), ('AAA'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('paper'), #000000), ('AAA'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('wheat'), #000000), ('AAA'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('sky'), #000000), ('AAA'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('mandarin'), #000000), ('AAA'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('lemon'), #000000), ('AAA'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('candy'), #000000), ('AAA'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('wasabi'), #000000), ('AAA'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('white'), #000000), ('AAA'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('teal'), #000000), ('AA18'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('crimson'), #000000), ('AA18'));
 		};
 
 		@include test('$color on #262a33 (slate)') {
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('org-b2c-light'), #262a33), ('AAA'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('paper'), #262a33), ('AAA'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('wheat'), #262a33), ('AAA'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('sky'), #262a33), ('AAA'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('mandarin'), #262a33), ('AA'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('lemon'), #262a33), ('AAA'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('candy'), #262a33), ('AA'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('wasabi'), #262a33), ('AAA'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('white'), #262a33), ('AAA'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('teal'), #000000), ('AA18'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('crimson'), #000000), ('AA18'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('org-b2c-light'), #262a33), ('AAA'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('paper'), #262a33), ('AAA'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('wheat'), #262a33), ('AAA'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('sky'), #262a33), ('AAA'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('mandarin'), #262a33), ('AA'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('lemon'), #262a33), ('AAA'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('candy'), #262a33), ('AA'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('wasabi'), #262a33), ('AAA'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('white'), #262a33), ('AAA'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('teal'), #000000), ('AA18'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('crimson'), #000000), ('AA18'));
 		};
 	};
 
 	@include describe('FAIL') {
 		@include test('$color on #ffffff (white)') {
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('wheat'), #ffffff), ('fail'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('sky'), #ffffff), ('fail'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('mandarin'), #ffffff), ('fail'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('lemon'), #ffffff), ('fail'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('candy'), #ffffff), ('fail'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('wasabi'), #ffffff), ('fail'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('org-b2c-light'), #ffffff), ('fail'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('wheat'), #ffffff), ('fail'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('sky'), #ffffff), ('fail'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('mandarin'), #ffffff), ('fail'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('lemon'), #ffffff), ('fail'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('candy'), #ffffff), ('fail'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('wasabi'), #ffffff), ('fail'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('org-b2c-light'), #ffffff), ('fail'));
 		};
 
 		@include test('$color on #fff1e5 (paper)') {
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('wheat'), #fff1e5), ('fail'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('sky'), #fff1e5), ('fail'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('mandarin'), #fff1e5), ('fail'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('lemon'), #fff1e5), ('fail'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('candy'), #fff1e5), ('fail'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('wasabi'), #fff1e5), ('fail'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('org-b2c-light'), #fff1e5), ('fail'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('wheat'), #fff1e5), ('fail'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('sky'), #fff1e5), ('fail'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('mandarin'), #fff1e5), ('fail'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('lemon'), #fff1e5), ('fail'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('candy'), #fff1e5), ('fail'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('wasabi'), #fff1e5), ('fail'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('org-b2c-light'), #fff1e5), ('fail'));
 		};
 
 		@include test('$color on #000000 (black)') {
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('slate'), #000000), ('fail'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('claret'), #000000), ('fail'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('oxford'), #000000), ('fail'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('velvet'), #000000), ('fail'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('slate'), #000000), ('fail'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('claret'), #000000), ('fail'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('oxford'), #000000), ('fail'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('velvet'), #000000), ('fail'));
 		};
 
 		@include test('$color on #262a33 (slate)') {
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('black'), #262a33), ('fail'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('claret'), #262a33), ('fail'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('oxford'), #262a33), ('fail'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('velvet'), #262a33), ('fail'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('teal'), #262a33), ('fail'));
-			@include assert-equal(oColorsGetWCAGRating(oColorsGetPaletteColor('crimson'), #262a33), ('fail'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('black'), #262a33), ('fail'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('claret'), #262a33), ('fail'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('oxford'), #262a33), ('fail'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('velvet'), #262a33), ('fail'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('teal'), #262a33), ('fail'));
+			@include assert-equal(oColorsGetWCAGRating(oColorsByName('crimson'), #262a33), ('fail'));
 		};
 	}
 }


### PR DESCRIPTION
- Replace `oColorsGetPaletteColor` with `oColorsGetPalette`.
- Make `$o-colors-palette` private.
- Add function `oColorsGetPalette` to iterate over the palette,
without being able to write to it directly.
- Remove `inherit` and `transparent` from the palette.
- Update `oColorsByName` to support deprecation messages.