### PR TITLE
Update `oColorsSetUseCase` and related Sass.

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -38,13 +38,15 @@ The following have been removed from the palette:
 
 The following variables have changed:
 
-- `$o-colors-palette` has been removed. Use `oColorsSetColor` to add to the palette, `oColorsByName` to fetch colors from the palette, and `oColorsGetPalette` to iterate over the palette.
+- `$o-colors-palette` has been removed. Use `oColorsSetColor` to add to the palette or customise a default o-colors palette colour; `oColorsByName` to fetch colors from the palette; or `oColorsGetPalette` to iterate over each colour in the palette.
+- `$o-colors-usecases` has been removed. Use `oColorsSetUseCase` to add to add a usecase or customise a default o-colors usecase; or `oColorsByUsecase` to fetch a colour for a usecase.
 
 The following mixins have changed:
 
 - `oColors` no longer outputs usecase CSS classes.
 - `oColorsGetPaletteColor` is now [`oColorsByName`](#oColorsByName).
 - [`oColorsSetColor`](#oColorsSetColor) has updated arguments.
+- [`oColorsSetUseCase`](#oColorsSetUseCase) has updated arguments.
 - `oColorsGetUseCase` is now [`oColorsByUsecase`](#oColorsByUsecase).
 
 #### oColors
@@ -120,7 +122,9 @@ Or with argument names:
 
 #### oColorsSetColor
 
-The arguments of `oColorsSetColor` have changed. And it now supports a colour deprecation message.
+- The arguments of `oColorsSetColor` have changed.
+- It now supports a colour deprecation message.
+- It errors when overriding an existing palette colour which was not set by o-colors.
 
 A project name must now be given explicitly, which is used to namespace the colour:
 ```diff
@@ -141,6 +145,39 @@ A custom deprecation message may be given:
 // Setting a  custom colour 'pink', which is deprecated, with a custom deprecation warning.
 - @include oColorsSetColor('o-example-pink', (#ff69b4, _deprecated));
 + @include oColorsSetColor('o-example', 'pink', #ff69b4, (deprecated: 'reason for deprecation'));
+```
+
+#### oColorsSetUseCase
+
+- The arguments of `oColorsSetUseCase` have changed.
+- It may also deprecate the properties of a colour usecase more granularly.
+- It errors when overriding an existing usecase which was not set by o-colors.
+
+A project name must now be given explicitly, which is used to namespace the usecase, and properties are given with a map:
+```diff
+// Setting a custom usecase within a component 'o-example'.
+// The usecase describes stripes, which have a background, text colour, and border.
+-@include oColorsSetUseCase('o-example-stripe', 'text', 'white');
+-@include oColorsSetUseCase('o-example-stripe', 'background', 'black');
+-@include oColorsSetUseCase('o-example-stripe', 'border', 'black-50');
++@include oColorsSetUseCase('o-example', 'stripe', (
++	'text': 'white',
++	'background': 'black',
++	'border': 'black-50'
++));
+```
+
+To deprecate a usecase pass a second options argument:
+```diff
+-@include oColorsSetUseCase('o-example-stripe', 'text', 'white');
+-@include oColorsSetUseCase('o-example-stripe', 'background', 'black');
+-@include oColorsSetUseCase('o-example-stripe', 'border', 'black-50');
+-@include oColorsSetUseCase('o-example-stripe', '_deprecated', 'There are no stripes anymore.');
++@include oColorsSetUseCase('o-example', 'stripe', (
++	'text': 'white',
++	'background': 'black',
++	'border': 'black-50'
++), ('deprecated': 'There are no stripes anymore.'));
 ```
 
 ### Upgrading from v3 to v4

--- a/README.md
+++ b/README.md
@@ -211,16 +211,21 @@ section-money-alt |     all
 You can add usecases for your particular component or product. This is done using the `oColorsSetUseCase` mixin:
 
 ```scss
-@include oColorsSetUseCase(email, text, 'black-60');
+@include oColorsSetUseCase('o-example', 'stripes', (
+	'text': 'white',
+	'background': 'black',
+	'border': 'black-50',
+));
 ```
 
-It takes three arguments:
+It takes four arguments:
 
-* **Usecase**: your particular usecase
-* **Property**: the property for which the color should be used for (background, border, or text)
-* **Color**: a color from the palette
+* **Project Name**: your component or project name
+* **Usecase**: your particular usecase name
+* **Colors**: a map of properties to colours (background, border, text, or outline)
+* **Opts**: a map of options. Accepts a `deprecated` key with a deprecation message for the usecase, or a map to deprecate a specific property.
 
-If you are creating a usecase for a component, you *must* namespace your usecase name with the name of your component.
+See [o-colors SassDoc](https://registry.origami.ft.com/components/o-colors/sassdoc?brand=master#o-colors-mixin-ocolorssetusecase) for more details and examples.
 
 You can also use `oColorsByUsecase` to retrieve the palette color name (eg `paper`) defined against a usecase. This can be useful when you need the palette color name to use with another Sass mixin.
 

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -29,7 +29,7 @@ body {
 
 	.o-colors-palette-#{$name} .hex,
 	.o-colors-palette-#{$name}:after {
-		color: oColorsGetTextColor($name, 95);
+		color: oColorsGetTextColor($name, 95,  $warnings: false);
 	}
 }
 

--- a/main.scss
+++ b/main.scss
@@ -14,7 +14,8 @@
 @import 'src/scss/mixins';
 
 // Set the palette colors programatically
-@include _oColorsSetPaletteColors;
+@include _oColorsSetDefaultPaletteColors;
+@include _oColorsSetDefaultUsecases;
 @include _oColorsSetPaletteTints;
 
 /// Output `o-colors` CSS classes and custom properties.

--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -87,47 +87,69 @@
 @function oColorsByUsecase($usecase, $property, $fallback: false, $from: 'o-colors') {
 	// Validate usecase is a string.
 	@if(type-of($usecase) != 'string') {
-		@return _error('`$usecase` should be a string but found "#{inspect($usecase)}" of type "#{type-of($usecase)}".');
+		@return _error('`$usecase` should be a string but found ' +
+		'"#{inspect($usecase)}" of type "#{type-of($usecase)}".');
 	}
+
 	// Validate from is a string.
 	@if(type-of($from) != 'string') {
-		@return _error('`$from` should be a string but found "#{inspect($from)}" of type "#{type-of($from)}".');
+		@return _error('`$from` should be a string but found ' +
+		'"#{inspect($from)}" of type "#{type-of($from)}".');
 	}
+
 	// Validate property is allowed.
 	$valid-properties: ('text', 'background', 'border', 'outline');
 	@if(not index($valid-properties, $property)) {
-		@return _error('`$property` should be one o "#{inspect($valid-properties)}" but found "#{inspect($property)}".');
+		@return _error('`$property` should be one of ' +
+		'"#{inspect($valid-properties)}" but found "#{inspect($property)}".');
 	}
+
 	// Validate fallback is a colour or null.
 	// `false` is used as a default to indicate the user has not passed a fallback.
 	$valid-fallback: type-of($fallback) == 'color' or type-of($fallback) == 'null';
 	@if($fallback != false and not $valid-fallback) {
-		@return _error('`$fallback` should be a valid colour or `null`, found "#{inspect($fallback)}".');
+		@return _error('`$fallback` should be a valid colour or `null`, ' +
+		'found "#{inspect($fallback)}".');
 	}
 
 	// Get properties for usecase. Error if none are found.
 	$namespaced-usecase: '#{$from}-#{$usecase}';
-	$props: map-get($o-colors-usecases, $namespaced-usecase);
-	@if($props == null) {
+	$config: map-get($_o-colors-usecases, $namespaced-usecase);
+	@if($config == null) {
 		@return if($valid-fallback, $fallback, _error(
-			'The colour usecase #{inspect($usecase)} couldn\'t be found for #{inspect($from)}'
-		));
-	}
-	// Get colour for usecase property. If none are found look for the property
-	// specifically, see if the usecase has set a colour for `all` properties.
-	// Error if no colour is found.
-	$color: map-get($props, $property);
-	$color: if($color, $color, map-get($props, all));
-	@if($color == null) {
-		@return if($valid-fallback, $fallback, _error(
-			'The colour usecase property #{inspect($property)} couldn\'t be found within the #{inspect($from)} #{inspect($usecase)} usecase.'
+			'The colour usecase #{inspect($usecase)} couldn\'t be found ' +
+			'for #{inspect($from)}'
 		));
 	}
 
-	// Output any deprecation warning.
-	// @todo: pre-major cascade, update to support granular usecase property deprecation.
-	@if ($props and map-has-key($props, '_deprecated')) {
-		@warn "Color use case '#{inspect($usecase)}' is deprecated (property '#{inspect($property)}' was requested): #{inspect(map-get($props, '_deprecated'))}";
+	// Get colour for usecase property. If none are found look for the property
+	// specifically, see if the usecase has set a colour for `all` properties.
+	// Error if no colour is found.
+	$colors: map-get($config, 'colors');
+	$color: map-get($colors, $property);
+	$color: if($color, $color, map-get($colors, all));
+	@if($color == null) {
+		@return if($valid-fallback, $fallback, _error(
+			'The colour usecase property #{inspect($property)} couldn\'t ' +
+			'be found within the #{inspect($from)} #{inspect($usecase)} usecase.'
+		));
+	}
+
+	// Output any deprecation warnings, if not already.
+	$opts: map-get($config, 'opts');
+	$deprecated: if(type-of($opts) == 'map', map-get($opts, 'deprecated'), null);
+	$deprecated-key: 'usecase-#{$namespaced-usecase}-#{$property}';
+	@if(not index($_o-colors-deprecation-warnings-output, $deprecated-key)) {
+		@if (type-of($deprecated) == 'string') {
+			@warn 'Color usecase "#{inspect($usecase)}" from #{inspect($from)} is deprecated ' +
+			'(property "#{inspect($property)}" was requested): #{inspect($deprecated)}';
+		}
+		@if (type-of($deprecated) == 'map' and map-has-key($deprecated, $property)) {
+			@warn 'The "#{inspect($property)}" property of "#{inspect($from)}" ' +
+			'"#{inspect($usecase)}" color usecase is deprecated: ' +
+			'#{inspect(map-get($deprecated, $property))}';
+		}
+		$_o-colors-deprecation-warnings-output: append($_o-colors-deprecation-warnings-output, $deprecated-key) !global;
 	}
 
 	@return $color;

--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -31,7 +31,7 @@
 	$deprecated: map-get($meta, 'deprecated');
 	$already-warned: index($_o-colors-deprecation-warnings-output, $namespaced-color-name) != null;
 	@if $deprecated and not $already-warned {
-		$deprecation-message: 'The color "#{$color-name}" from "#{$from}" is deprecated for the "#{$_o-colors-brand}" palette, and will be removed in the next major.';
+		$deprecation-message: 'The color "#{$color-name}" from "#{$from}" is deprecated for the "#{oBrandGetCurrentBrand()}" palette, and will be removed in the next major.';
 		// Append any custom deprecation message.
 		$deprecation-message: if(type-of($deprecated) != 'string', $deprecation-message, $deprecation-message + ' ' + $deprecated);
 		// Output warning.

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -14,7 +14,7 @@
 /// @param {String} $project-name - The name of the component or project setting this colour, e.g. 'o-example'.
 /// @param {String} $color-name - The name of the colour e.g. 'paper'.
 /// @param {Color} $color-hex - The colour to set (hex) e.g. #ff69b4.
-/// @param {Map} $opts - A map of options. Accepts a `deprecated` key with a message to deprecated a set colour e.g. `$opts: (deprecated: 'your deprecation message')`.
+/// @param {Map} $opts [()] - A map of options. Accepts a `deprecated` key with a message to deprecated a set colour e.g. `$opts: (deprecated: 'your deprecation message')`.
 @mixin oColorsSetColor($project-name, $color-name, $color-hex, $opts: ()) {
 	// Validate arguments are of correct type.
 	$missing-namespace: type-of($project-name) != 'string';
@@ -24,12 +24,33 @@
 		@error 'Expected a string `$project-name` and `$color-name` to set a new colour.';
 	}
 	@if $missing-color-hex {
-		@error 'Expected `$color-hex ` to be a colour, found "#{$color-hex}" of type "#{type-of($color-hex)}".';
+		@error 'Expected `$color-hex` to be a colour, found "#{$color-hex}" of type "#{type-of($color-hex)}".';
 	}
 	// Get the namespaced color name.
 	$namespaced-color-name: '#{$project-name}-#{$color-name}';
-	// Set the new colour to the colour palette.
+	$color-exists: map-has-key($_o-colors-palette, $namespaced-color-name);
+
+	// Get deprecation message.
 	$deprecation-message: map-get($opts, 'deprecated');
+
+	// Default o-colors palette colours may not be deprecated by users.
+	@if ($project-name == 'o-colors' and $color-exists and $deprecation-message) {
+		@error 'Default o-colors palette colours may not be deprecated by users of o-colors.';
+	}
+
+	// Default o-colors palette colours may be customised by users but
+	// existing project/component usecases may not:
+	// Error if the palette colour already exists and isn't an o-colors default.
+	// Palette colours may be used by projects to share colour values but
+	// customisation usually happens with component specific mixins.
+	@if ($project-name != 'o-colors' and $color-exists) {
+		@error 'A palette colour "#{$color-name}" has already been set for "#{$project-name}".\n' +
+		'Only default o-colors palette colours may be overridden with `oColorsSetColor`. ' +
+		'If you would like to customise "#{$project-name}" colours, check its README for ' +
+		'customisation options, or contact the Origami team to propose new customisation features.';
+	}
+
+	// Set the new colour to the colour palette.
 	$new-color: ($namespaced-color-name: (
 		'color': $color-hex,
 		'name': $color-name,
@@ -39,28 +60,63 @@
 	$_o-colors-palette: map-merge($_o-colors-palette, $new-color) !global;
 };
 
-/// Add a custom use case property
+/// Add a custom use case property.
 ///
-/// @example scss
-///  @include oColorsSetUseCase(email, text, 'grey-tint5');
+/// @example Setting a 'stripe' usecase with background, text, and border colour within a component 'o-example'.
+///     @include oColorsSetUseCase('o-example', 'stripe', (
+///     	'text': 'white',
+///     	'background': 'black',
+///     	'border': 'black-50'
+///     ));
 ///
-/// @param {String} $usecase - Name of the use case
-/// @param {String} $property - Property it applies to
-/// @param {String} $color - One of $_o-colors-palette
-@mixin oColorsSetUseCase($usecase, $property, $color) {
-	$namespaced-usecase: 'o-colors-#{$usecase}';
-	$propmap: ($property: $color);
+/// @example Deprecating all usecase properties (removing a colour usecase is a breaking change).
+///     @include oColorsSetUseCase('o-example', 'stripe', (
+///     	'text': 'white',
+///     	'background': 'black',
+///     	'border': 'black-50'
+///     ), (deprecated: 'o-example has no stripes anymore.'));
+///
+/// @example Deprecating particular usecase properties e.g. "border" (removing a usecase property is a breaking change).
+///    @include oColorsSetUseCase('o-example', 'stripe', (
+///     		'text': 'white',
+///     		'background': 'black',
+///     		'border': 'black-50',
+///		), ('deprecated': ('border': 'o-example stripes have no border anymore.')));
+///
+/// @param {String} $project-name - The name of the component or project setting this colour, e.g. 'o-example'.
+/// @param {String} $usecase - The name of the usecase, e.g. 'page'.
+/// @param {Map} $colors - A map of properties ('text', 'background', 'border', or 'outline') to a color.
+/// @param {Map} $opts [()] - A map of options. Accepts a `deprecated` key with a deprecation message for the usecase e.g. `$opts: (deprecated: 'your deprecation message')`, or a map to deprecate a specific property e.g. `(deprecated: (background: 'your deprecation message'))`.
+@mixin oColorsSetUseCase($project-name, $usecase, $colors, $opts: ()) {
+	$namespaced-usecase: '#{$project-name}-#{$usecase}';
 
-	// The use-case already exists,
-	// combine its existing properties with the new one
-	@if (map-has-key($o-colors-usecases, $namespaced-usecase)) {
-		$propmap: map-merge(map-get($o-colors-usecases, $namespaced-usecase), $propmap);
+	// Default o-colors usecases may not be deprecated by users.
+	@if ($project-name == 'o-colors' and map-has-key($opts, 'deprecated')) {
+		@error 'Default o-colors usecases may not be deprecated by users of o-colors.';
 	}
 
-	$newmap: ($namespaced-usecase: $propmap);
+	// Default o-colors usecases may be customised by users.
+	@if ($project-name == 'o-colors' and map-has-key($_o-colors-usecases, $namespaced-usecase)) {
+		$current-config: map-get($_o-colors-usecases, $namespaced-usecase);
+		$current-colors: map-get($current-config, 'colors');
+		$colors: map-merge($current-colors, $colors);
+	}
 
-	// Add the use-case and its properties to the global use-case map
-	$o-colors-usecases: map-merge($o-colors-usecases, $newmap) !global;
+	// Existing project/component usecases may not be customised by users:
+	// Error if the use-case already exists and isn't an o-colors usecase.
+	// Usecases may be used by projects to share colour values but customisation
+	// usually happens on the component level, with component specific mixins.
+	@if ($project-name != 'o-colors' and map-has-key($_o-colors-usecases, $namespaced-usecase)) {
+		@error 'A usecase "#{$usecase}" has already been set for "#{$project-name}".\n' +
+		'Only default o-colors usecases may be overridden with `oColorsSetUseCase`. ' +
+		'If you would like to customise "#{$project-name}" colours, check its README for ' +
+		'customisation options, or contact the Origami team to propose new customisation features.';
+	}
+
+	// Add the use-case and its properties to the global use-case map.
+	$_o-colors-usecases: map-merge($_o-colors-usecases, (
+		$namespaced-usecase: ('colors': $colors, 'opts': $opts)
+	)) !global;
 }
 
 /// Output property declarations for all defined properties for the specified use case
@@ -135,7 +191,6 @@
 					$tint: _oColorsHSB($hue, $saturation, $value);
 				}
 
-				// @todo use oColorsSetColor
 				@include oColorsSetColor('o-colors', $name, $tint, $opts: (
 					'deprecated': $deprecated
 				));

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -199,12 +199,19 @@
 	}
 }
 
-/// Update the palette with default o-colors palette colours.
-@mixin _oColorsSetPaletteColors {
-	@each $color-name, $color-details in $_o-colors-default-palette-colors {
-		$color-hex: map-get($color-details, 'color');
-		$opts: map-get($color-details, 'opts');
+/// Add default o-colors palette colours.
+@mixin _oColorsSetDefaultPaletteColors {
+	@each $color-name, $color-hex, $opts in $_o-colors-default-palette-colors {
+		$opts: if($opts, $opts, ());
 		@include oColorsSetColor('o-colors', $color-name, $color-hex, $opts);
+	}
+}
+
+/// Add default o-colors usecases.
+@mixin _oColorsSetDefaultUsecases {
+	@each $usecase, $colors, $opts in $_o-colors-default-usecases {
+		$opts: if($opts, $opts, ());
+		@include oColorsSetUseCase('o-colors', $usecase, $colors, $opts);
 	}
 }
 

--- a/src/scss/_palette.scss
+++ b/src/scss/_palette.scss
@@ -1,107 +1,107 @@
 // Define universal primary palette.
-$_o-colors-default-palette-colors: map-merge((
-	'black':                 ('color': #000000, 'opts': ()),
-	'white':                 ('color': #ffffff, 'opts': ()),
+$_o-colors-default-palette-colors: join((
+	('black', #000000),
+	('white', #ffffff),
 ), $_o-colors-default-palette-colors);
 
 // Master brand palette.
-@if $_o-colors-brand == master {
-	$_o-colors-default-palette-colors: map-merge((
+@if oBrandGetCurrentBrand() == master {
+	$_o-colors-default-palette-colors: join((
 		// primary palette
-		'paper':                 ('color': #fff1e5, 'opts': ()),
-		'claret':                ('color': #990f3d, 'opts': ()),
-		'oxford':                ('color': #0f5499, 'opts': ()),
-		'teal':                  ('color': #0d7680, 'opts': ()),
+		('paper', #fff1e5),
+		('claret', #990f3d),
+		('oxford', #0f5499),
+		('teal', #0d7680),
 
 		//secondary palette
-		'wheat':                 ('color': #f2dfce, 'opts': ()),
-		'sky':                   ('color': #cce6ff, 'opts': ()),
-		'slate':                 ('color': #262a33, 'opts': ()),
-		'velvet':                ('color': #593380, 'opts': ()),
-		'mandarin':              ('color': #ff8833, 'opts': ()),
-		'lemon':                 ('color': #ffec1a, 'opts': ()),
+		('wheat', #f2dfce),
+		('sky', #cce6ff),
+		('slate', #262a33),
+		('velvet', #593380),
+		('mandarin', #ff8833),
+		('lemon', #ffec1a),
 
 		//tertiary palette
-		'candy':                 ('color': #ff7faa, 'opts': ()),
-		'wasabi':                ('color': #96cc28, 'opts': ()),
-		'jade':                  ('color': #00994d, 'opts': ()),
-		'crimson':               ('color': #cc0000, 'opts': ()),
+		('candy', #ff7faa),
+		('wasabi', #96cc28),
+		('jade', #00994d),
+		('crimson', #cc0000),
 
 		//b2c palette
-		'org-b2c':               ('color': #4e96eb, 'opts': ()),
-		'org-b2c-dark':          ('color': #3a70af, 'opts': ()),
-		'org-b2c-light':         ('color': #99c6fb, 'opts': ()),
+		('org-b2c', #4e96eb),
+		('org-b2c-dark', #3a70af),
+		('org-b2c-light', #99c6fb),
 	), $_o-colors-default-palette-colors);
 }
 
 // Internal brand palette.
-@if $_o-colors-brand == internal {
-	$_o-colors-default-palette-colors: map-merge((
+@if oBrandGetCurrentBrand() == internal {
+	$_o-colors-default-palette-colors: join((
 		// primary palette
-		'oxford':         ('color': #0f5499, 'opts': ()),
-		'teal':           ('color': #0d7680, 'opts': ()),
-		'paper':          ('color': #fff1e5, 'opts': ('deprecated': true)),
-		'claret':         ('color': #990f3d, 'opts': ('deprecated': true)),
+		('oxford', #0f5499),
+		('teal', #0d7680),
+		('paper', #fff1e5, ('deprecated': true)),
+		('claret', #990f3d, ('deprecated': true)),
 
 		//secondary palette
-		'lemon':          ('color': #ffec1a, 'opts': ()),
-		'slate':          ('color': #262a33, 'opts': ()),
-		'wheat':          ('color': #f2dfce, 'opts': ('deprecated': true)),
-		'sky':            ('color': #cce6ff, 'opts': ('deprecated': true)),
-		'velvet':         ('color': #593380, 'opts': ('deprecated': true)),
-		'mandarin':       ('color': #ff8833, 'opts': ('deprecated': true)),
+		('lemon', #ffec1a),
+		('slate', #262a33),
+		('wheat', #f2dfce, ('deprecated': true)),
+		('sky', #cce6ff, ('deprecated': true)),
+		('velvet', #593380, ('deprecated': true)),
+		('mandarin', #ff8833, ('deprecated': true)),
 
 		//tertiary palette
-		'jade':           ('color': #00994d, 'opts': ()),
-		'crimson':        ('color': #cc0000, 'opts': ()),
-		'candy':          ('color': #ff7faa, 'opts': ('deprecated': true)),
-		'wasabi':         ('color': #96cc28, 'opts': ('deprecated': true)),
+		('jade', #00994d),
+		('crimson', #cc0000),
+		('candy', #ff7faa, ('deprecated': true)),
+		('wasabi', #96cc28, ('deprecated': true)),
 
 		//b2c palette
-		'org-b2c':        ('color': #4e96eb, 'opts': ('deprecated': true)),
-		'org-b2c-dark':   ('color': #3a70af, 'opts': ('deprecated': true)),
-		'org-b2c-light':  ('color': #99c6fb, 'opts': ('deprecated': true)),
+		('org-b2c', #4e96eb, ('deprecated': true)),
+		('org-b2c-dark', #3a70af, ('deprecated': true)),
+		('org-b2c-light', #99c6fb, ('deprecated': true)),
 	), $_o-colors-default-palette-colors);
 
 	// Add experimental colors to support work on the internal brand design.
-	$_o-colors-default-palette-colors: map-merge((
-		'slate-white-15': ('color': #dedfe0, 'opts': ()), // oColorsMix('slate', 'white', 15): to support work on internal brand design
-		'slate-white-5':  ('color': #f4f4f5, 'opts': ()), // oColorsMix('slate', 'white', 5): to support work on internal brand design
+	$_o-colors-default-palette-colors: join((
+		('slate-white-15', #dedfe0), // oColorsMix('slate', 'white', 15): to support work on internal brand design
+		('slate-white-5', #f4f4f5), // oColorsMix('slate', 'white', 5): to support work on internal brand design
 	), $_o-colors-default-palette-colors);
 }
 
 // Whitelabel brand palette.
-@if $_o-colors-brand == whitelabel {
-	$_o-colors-default-palette-colors: map-merge((
+@if oBrandGetCurrentBrand() == whitelabel {
+	$_o-colors-default-palette-colors: join((
 		// primary palette
-		'oxford':         ('color': #0f5499, 'opts': ('deprecated': true)),
-		'teal':           ('color': #0d7680, 'opts': ('deprecated': true)),
-		'paper':          ('color': #fff1e5, 'opts': ('deprecated': true)),
-		'claret':         ('color': #990f3d, 'opts': ('deprecated': true)),
+		('oxford', #0f5499, ('deprecated': true)),
+		('teal', #0d7680, ('deprecated': true)),
+		('paper', #fff1e5, ('deprecated': true)),
+		('claret', #990f3d, ('deprecated': true)),
 
 		//secondary palette
-		'lemon':          ('color': #ffec1a, 'opts': ('deprecated': true)),
-		'slate':          ('color': #262a33, 'opts': ('deprecated': true)),
-		'wheat':          ('color': #f2dfce, 'opts': ('deprecated': true)),
-		'sky':            ('color': #cce6ff, 'opts': ('deprecated': true)),
-		'velvet':         ('color': #593380, 'opts': ('deprecated': true)),
-		'mandarin':       ('color': #ff8833, 'opts': ('deprecated': true)),
+		('lemon', #ffec1a, ('deprecated': true)),
+		('slate', #262a33, ('deprecated': true)),
+		('wheat', #f2dfce, ('deprecated': true)),
+		('sky', #cce6ff, ('deprecated': true)),
+		('velvet', #593380, ('deprecated': true)),
+		('mandarin', #ff8833, ('deprecated': true)),
 
 		//tertiary palette
-		'jade':           ('color': #00994d, 'opts': ('deprecated': true)),
-		'crimson':        ('color': #cc0000, 'opts': ('deprecated': true)),
-		'candy':          ('color': #ff7faa, 'opts': ('deprecated': true)),
-		'wasabi':         ('color': #96cc28, 'opts': ('deprecated': true)),
+		('jade', #00994d, ('deprecated': true)),
+		('crimson', #cc0000, ('deprecated': true)),
+		('candy', #ff7faa, ('deprecated': true)),
+		('wasabi', #96cc28, ('deprecated': true)),
 
 		//b2c palette
-		'org-b2c':        ('color': #4e96eb, 'opts': ('deprecated': true)),
-		'org-b2c-dark':   ('color': #3a70af, 'opts': ('deprecated': true)),
-		'org-b2c-light':  ('color': #99c6fb, 'opts': ('deprecated': true)),
+		('org-b2c', #4e96eb, ('deprecated': true)),
+		('org-b2c-dark', #3a70af, ('deprecated': true)),
+		('org-b2c-light', #99c6fb, ('deprecated': true)),
 	), $_o-colors-default-palette-colors);
 }
 
 // Master brand palette tints.
-@if $_o-colors-brand == master {
+@if oBrandGetCurrentBrand() == master {
 	$o-colors-tints: map-merge((
 		'black': (
 			tints: (5, 10, 20, 30, 40, 50, 60, 70, 80, 90),
@@ -168,7 +168,7 @@ $_o-colors-default-palette-colors: map-merge((
 }
 
 // Internal brand palette tints.
-@if $_o-colors-brand == internal {
+@if oBrandGetCurrentBrand() == internal {
 	$o-colors-tints: map-merge((
 		'black': (
 			tints: (5, 10, 20, 30, 40, 50, 60, 70, 80, 90),
@@ -242,7 +242,7 @@ $_o-colors-default-palette-colors: map-merge((
 }
 
 // Whitelabel brand palette tints.
-@if $_o-colors-brand == whitelabel {
+@if oBrandGetCurrentBrand() == whitelabel {
 	$o-colors-tints: map-merge((
 		'black': (
 			tints: (5, 10, 20, 30, 40, 50, 60, 70, 80, 90),

--- a/src/scss/_use-cases.scss
+++ b/src/scss/_use-cases.scss
@@ -1,74 +1,93 @@
-////
-/// @group o-colors
-/// @link http://registry.origami.ft.com/components/o-colors
-////
-
-/// color use cases
-///
-/// These mappings define what we use our colors for.
-///
-/// Use case:           Must be a single word comprising just letters, numbers, and dashes.
-/// Properties:         A Sass map of colours `colors` and options `opts`.
-/// Properties-colors:  A Sass map of properties (must be 'border', 'text', 'background', 'outline', or 'all')
-///                     against palette colors (must be an exact match for a name of a color defined
-///                     in palette.scss).
-/// Properties-opts:    A Sass map of options. May include a 'deprecated' key with a deprecation message for
-///						the usecase, or a map of deprecation messages for each usecase property.
-///						E.g. `('deprecated': 'this usecase is not used anymore.')`
-///						E.g. `('deprecated': ('border': 'this usecase has no border property anymore'))`
-///
-/// @type map
-$_o-colors-branded-usecases: (
-	'master': (
-		//	<use case>						<properties>
-		o-colors-focus:						('colors': (outline: 'black-50'), 'opts': ()),
-		o-colors-page:						('colors': (background: 'paper'), 'opts': ()),
-		o-colors-box:						('colors': (background: 'wheat'), 'opts': ()),
-		o-colors-link:						('colors': (text: 'teal'), 'opts': ()),
-		o-colors-link-hover:				('colors': (text: 'teal-30'), 'opts': ()),
-		o-colors-link-title:				('colors': (text: 'black-80'), 'opts': ()),
-		o-colors-link-title-hover:			('colors': (text: 'black-70'), 'opts': ()),
-		o-colors-tag-link:					('colors': (text: 'claret'), 'opts': ()),
-		o-colors-tag-link-hover:			('colors': (text: 'claret-30'), 'opts': ()),
-		o-colors-opinion-tag-link:			('colors': (text: 'oxford'), 'opts': ()),
-		o-colors-opinion-tag-link-hover:	('colors': (text: 'oxford-30'), 'opts': ()),
-		o-colors-title:						('colors': (text: 'black'), 'opts': ()),
-		o-colors-body:						('colors': (text: 'black-80'), 'opts': ()),
-		o-colors-muted:						('colors': (text: 'black-20'), 'opts': ()),
-		o-colors-opinion:					('colors': (background: 'sky'), 'opts': ()),
-		o-colors-hero:						('colors': (background: 'wheat'), 'opts': ()),
-		o-colors-hero-opinion:				('colors': (background: 'oxford'), 'opts': ()),
-		o-colors-hero-highlight:			('colors': (background: 'claret'), 'opts': ()),
+@if oBrandGetCurrentBrand() == master {
+	$_o-colors-default-usecases: (
+		('focus', ('outline': 'black-50')),
+		('page', ('background': 'paper')),
+		('box', ('background': 'wheat')),
+		('link', ('text': 'teal')),
+		('link-hover', ('text': 'teal-30')),
+		('link-title', ('text': 'black-80')),
+		('link-title-hover', ('text': 'black-70')),
+		('tag-link', ('text': 'claret')),
+		('tag-link-hover', ('text': 'claret-30')),
+		('opinion-tag-link', ('text': 'oxford')),
+		('opinion-tag-link-hover', ('text': 'oxford-30')),
+		('title', ('text': 'black')),
+		('body', ('text': 'black-80')),
+		('muted', ('text': 'black-20')),
+		('opinion', ('background': 'sky')),
+		('hero', ('background': 'wheat')),
+		('hero-opinion', ('background': 'oxford')),
+		('hero-highlight', ('background': 'claret')),
 
 		// Section colors
-		o-colors-section-life-arts:			('colors': (all: 'velvet'), 'opts': ()),
-		o-colors-section-life-arts-alt:		('colors': (all: 'candy'), 'opts': ()),
-		o-colors-section-magazine:			('colors': (all: 'oxford'), 'opts': ()),
-		o-colors-section-magazine-alt:		('colors': (all: 'sky'), 'opts': ()),
-		o-colors-section-house-home:		('colors': (all: 'jade'), 'opts': ()),
-		o-colors-section-house-home-alt:	('colors': (all: 'wasabi'), 'opts': ()),
-		o-colors-section-money:				('colors': (all: 'crimson'), 'opts': ()),
-		o-colors-section-money-alt:			('colors': (all: 'white'), 'opts': ()),
-	),
-	'internal': (
-		//	<use case>						<properties>
-		o-colors-focus:						('colors': (outline: 'oxford-80'), 'opts': ()),
-		o-colors-page:						('colors': (background: 'white'), 'opts': ()),
-		o-colors-box:						('colors': (background: 'slate-white-5'), 'opts': ()),
-		o-colors-link:						('colors': (text: 'teal'), 'opts': ()),
-		o-colors-link-hover:				('colors': (text: 'teal-30'), 'opts': ()),
-		o-colors-link-title:				('colors': (text: 'slate-white-15'), 'opts': ()),
-		o-colors-link-title-hover:			('colors': (text: 'slate-white-15'), 'opts': ()),
-		o-colors-title:						('colors': (text: 'slate'), 'opts': ()),
-		o-colors-body:						('colors': (text: 'slate'), 'opts': ()),
-		o-colors-muted:						('colors': (text: 'black-20'), 'opts': ()),
-	),
-	'whitelabel': (
-		//	<use case>						<properties>
-		o-colors-page:						('colors': (background: 'white'), 'opts': ()),
-	)
-);
+		('section-life-arts', (
+			'text': 'velvet',
+			'background': 'velvet',
+			'border': 'velvet',
+			'outline': 'velvet'
+		)),
+		('section-life-arts-alt', (
+			'text': 'candy',
+			'background': 'candy',
+			'border': 'candy',
+			'outline': 'candy'
+		)),
+		('section-magazine', (
+			'text': 'oxford',
+			'background': 'oxford',
+			'border': 'oxford',
+			'outline': 'oxford'
+		)),
+		('section-magazine-alt', (
+			'text': 'sky',
+			'background': 'sky',
+			'border': 'sky',
+			'outline': 'sky'
+		)),
+		('section-house-home', (
+			'text': 'jade',
+			'background': 'jade',
+			'border': 'jade',
+			'outline': 'jade'
+		)),
+		('section-house-home-alt', (
+			'text': 'wasabi',
+			'background': 'wasabi',
+			'border': 'wasabi',
+			'outline': 'wasabi'
+		)),
+		('section-money', (
+			'text': 'crimson',
+			'background': 'crimson',
+			'border': 'crimson',
+			'outline': 'crimson'
+		)),
+		('section-money-alt', (
+			'text': 'white',
+			'background': 'white',
+			'border': 'white',
+			'outline': 'white'
+		)),
+	);
+};
 
-$_o-colors-default-brand-usecases: map-get($_o-colors-branded-usecases, 'master');
-$_o-colors-current-brand-usecases: map-get($_o-colors-branded-usecases, $_o-colors-brand);
-$_o-colors-usecases: map-merge(if($_o-colors-current-brand-usecases, $_o-colors-current-brand-usecases, $_o-colors-default-brand-usecases), $_o-colors-usecases);
+@if oBrandGetCurrentBrand() == internal {
+	$_o-colors-default-usecases: (
+		('focus', ('outline': 'oxford-80')),
+		('page', ('background': 'white')),
+		('box', ('background': 'slate-white-5')),
+		('link', ('text': 'teal')),
+		('link-hover', ('text': 'teal-30')),
+		('link-title', ('text': 'slate-white-15')),
+		('link-title-hover', ('text': 'slate-white-15')),
+		('title', ('text': 'slate')),
+		('body', ('text': 'slate')),
+		('muted', ('text': 'black-20')),
+	);
+};
+
+@if oBrandGetCurrentBrand() == whitelabel {
+	$_o-colors-default-usecases: (
+		('page', ('background': 'white')),
+	);
+};

--- a/src/scss/_use-cases.scss
+++ b/src/scss/_use-cases.scss
@@ -8,69 +8,67 @@
 /// These mappings define what we use our colors for.
 ///
 /// Use case:           Must be a single word comprising just letters, numbers, and dashes.
-/// Properties:         A Sass map of properties (must be 'border', 'text', 'background', or 'all')
+/// Properties:         A Sass map of colours `colors` and options `opts`.
+/// Properties-colors:  A Sass map of properties (must be 'border', 'text', 'background', 'outline', or 'all')
 ///                     against palette colors (must be an exact match for a name of a color defined
 ///                     in palette.scss).
-///
-/// Special properties: You can use the following special properties to mark use cases:
-///
-///                     _deprecated: <msg>  Emits <msg> as a warning if referenced, but still works
+/// Properties-opts:    A Sass map of options. May include a 'deprecated' key with a deprecation message for
+///						the usecase, or a map of deprecation messages for each usecase property.
+///						E.g. `('deprecated': 'this usecase is not used anymore.')`
+///						E.g. `('deprecated': ('border': 'this usecase has no border property anymore'))`
 ///
 /// @type map
-
-//TODO: Include explanation for mapped usecases once they have been made permanent and publicly available
-
 $_o-colors-branded-usecases: (
 	'master': (
-	//	<use case>                <properties>
-		o-colors-focus:                    (outline: 'black-50'),
-		o-colors-page:                     (background: 'paper'),
-		o-colors-box:                      (background: 'wheat'),
-		o-colors-link:                     (text: 'teal'),
-		o-colors-link-hover:               (text: 'teal-30'),
-		o-colors-link-title:               (text: 'black-80'),
-		o-colors-link-title-hover:         (text: 'black-70'),
-		o-colors-tag-link:                 (text: 'claret'),
-		o-colors-tag-link-hover:           (text: 'claret-30'),
-		o-colors-opinion-tag-link:         (text: 'oxford'),
-		o-colors-opinion-tag-link-hover:   (text: 'oxford-30'),
-		o-colors-title:                    (text: 'black'),
-		o-colors-body:                     (text: 'black-80'),
-		o-colors-muted:                    (text: 'black-20'),
-		o-colors-opinion:                  (background: 'sky'),
-		o-colors-hero:                     (background: 'wheat'),
-		o-colors-hero-opinion:             (background: 'oxford'),
-		o-colors-hero-highlight:           (background: 'claret'),
+		//	<use case>						<properties>
+		o-colors-focus:						('colors': (outline: 'black-50'), 'opts': ()),
+		o-colors-page:						('colors': (background: 'paper'), 'opts': ()),
+		o-colors-box:						('colors': (background: 'wheat'), 'opts': ()),
+		o-colors-link:						('colors': (text: 'teal'), 'opts': ()),
+		o-colors-link-hover:				('colors': (text: 'teal-30'), 'opts': ()),
+		o-colors-link-title:				('colors': (text: 'black-80'), 'opts': ()),
+		o-colors-link-title-hover:			('colors': (text: 'black-70'), 'opts': ()),
+		o-colors-tag-link:					('colors': (text: 'claret'), 'opts': ()),
+		o-colors-tag-link-hover:			('colors': (text: 'claret-30'), 'opts': ()),
+		o-colors-opinion-tag-link:			('colors': (text: 'oxford'), 'opts': ()),
+		o-colors-opinion-tag-link-hover:	('colors': (text: 'oxford-30'), 'opts': ()),
+		o-colors-title:						('colors': (text: 'black'), 'opts': ()),
+		o-colors-body:						('colors': (text: 'black-80'), 'opts': ()),
+		o-colors-muted:						('colors': (text: 'black-20'), 'opts': ()),
+		o-colors-opinion:					('colors': (background: 'sky'), 'opts': ()),
+		o-colors-hero:						('colors': (background: 'wheat'), 'opts': ()),
+		o-colors-hero-opinion:				('colors': (background: 'oxford'), 'opts': ()),
+		o-colors-hero-highlight:			('colors': (background: 'claret'), 'opts': ()),
 
 		// Section colors
-		o-colors-section-life-arts:        (all: 'velvet'),
-		o-colors-section-life-arts-alt:    (all: 'candy'),
-		o-colors-section-magazine:         (all: 'oxford'),
-		o-colors-section-magazine-alt:     (all: 'sky'),
-		o-colors-section-house-home:       (all: 'jade'),
-		o-colors-section-house-home-alt:   (all: 'wasabi'),
-		o-colors-section-money:            (all: 'crimson'),
-		o-colors-section-money-alt:        (all: 'white'),
+		o-colors-section-life-arts:			('colors': (all: 'velvet'), 'opts': ()),
+		o-colors-section-life-arts-alt:		('colors': (all: 'candy'), 'opts': ()),
+		o-colors-section-magazine:			('colors': (all: 'oxford'), 'opts': ()),
+		o-colors-section-magazine-alt:		('colors': (all: 'sky'), 'opts': ()),
+		o-colors-section-house-home:		('colors': (all: 'jade'), 'opts': ()),
+		o-colors-section-house-home-alt:	('colors': (all: 'wasabi'), 'opts': ()),
+		o-colors-section-money:				('colors': (all: 'crimson'), 'opts': ()),
+		o-colors-section-money-alt:			('colors': (all: 'white'), 'opts': ()),
 	),
 	'internal': (
-	//	<use case>                <properties>
-		o-colors-focus:                    (outline: 'oxford-80'),
-		o-colors-page:                     (background: 'white'),
-		o-colors-box:                      (background: 'slate-white-5'),
-		o-colors-link:                     (text: 'teal'),
-		o-colors-link-hover:               (text: 'teal-30'),
-		o-colors-link-title:               (text: 'slate-white-15'),
-		o-colors-link-title-hover:         (text: 'slate-white-15'),
-		o-colors-title:                    (text: 'slate'),
-		o-colors-body:                     (text: 'slate'),
-		o-colors-muted:                    (text: 'black-20'),
+		//	<use case>						<properties>
+		o-colors-focus:						('colors': (outline: 'oxford-80'), 'opts': ()),
+		o-colors-page:						('colors': (background: 'white'), 'opts': ()),
+		o-colors-box:						('colors': (background: 'slate-white-5'), 'opts': ()),
+		o-colors-link:						('colors': (text: 'teal'), 'opts': ()),
+		o-colors-link-hover:				('colors': (text: 'teal-30'), 'opts': ()),
+		o-colors-link-title:				('colors': (text: 'slate-white-15'), 'opts': ()),
+		o-colors-link-title-hover:			('colors': (text: 'slate-white-15'), 'opts': ()),
+		o-colors-title:						('colors': (text: 'slate'), 'opts': ()),
+		o-colors-body:						('colors': (text: 'slate'), 'opts': ()),
+		o-colors-muted:						('colors': (text: 'black-20'), 'opts': ()),
 	),
 	'whitelabel': (
-	//	<use case>                <properties>
-		o-colors-page:                     (background: 'white'),
+		//	<use case>						<properties>
+		o-colors-page:						('colors': (background: 'white'), 'opts': ()),
 	)
 );
 
 $_o-colors-default-brand-usecases: map-get($_o-colors-branded-usecases, 'master');
 $_o-colors-current-brand-usecases: map-get($_o-colors-branded-usecases, $_o-colors-brand);
-$o-colors-usecases: map-merge(if($_o-colors-current-brand-usecases, $_o-colors-current-brand-usecases, $_o-colors-default-brand-usecases), $o-colors-usecases);
+$_o-colors-usecases: map-merge(if($_o-colors-current-brand-usecases, $_o-colors-current-brand-usecases, $_o-colors-default-brand-usecases), $_o-colors-usecases);

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -16,7 +16,7 @@ $_o-colors-default-palette-colors: () !default;
 $_o-colors-palette: () !default;
 $o-colors-tints: ();
 
-$o-colors-usecases: () !default;
+$_o-colors-usecases: () !default;
 
 // These are common usecase which are not necessarily defined for each brand.
 // When the usecase is used and `null` is returned, there is no need to warn about it.

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -1,22 +1,27 @@
 $o-colors-is-silent: true !default;
 
-/// Brand to define colours conditionally.
+/// A list of arguments for `oColorsSetColor`, except the project name. Used
+/// to set default palette colours.
 ///
-/// @type String
-$_o-colors-brand: oBrandGetCurrentBrand();
-
-/// Default FT colours to add to the colour palette.
-/// @prop {Map}
-/// @prop {Map} base.color-name - Where `color-name` is the name of the colour, e.g. paper.
-/// @prop {Color} base.color-name.color - The color for the colour name.
-/// @prop {Map} base.color-name.opts - Extra details about the colour.
-/// @prop {String|Boolean} base.color-name.opts.deprecated - True, or a deprecation message, if the colour is deprecated.
+/// @see _oColorsSetDefaultPaletteColors
+/// @see oColorsSetColor
+///
+/// @type list
 $_o-colors-default-palette-colors: () !default;
 
-$_o-colors-palette: () !default;
-$o-colors-tints: ();
+/// A list of arguments for `oColorsSetUseCase`, except the project name. Used
+/// to set default usecases.
+///
+/// @see _oColorsSetDefaultUsecases
+/// @see oColorsSetUseCase
+///
+/// @type list
+$_o-colors-default-usecases: () !default;
+
 
 $_o-colors-usecases: () !default;
+$_o-colors-palette: () !default;
+$o-colors-tints: ();
 
 // These are common usecase which are not necessarily defined for each brand.
 // When the usecase is used and `null` is returned, there is no need to warn about it.

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -52,20 +52,38 @@
 			@include oColorsSetColor('o-colors', 'olive', #808000);
 			@include assert-equal(oColorsByName('olive'), (#808000))
 		};
+		@include it('override a default o-colors palette color') {
+			@include oColorsSetColor('o-colors', 'paper', #808000);
+			@include assert-equal(oColorsByName('paper'), (#808000))
+		};
 	};
 
 	@include describe('oColorSetUseCase') {
 		@include it('add a custom use case property') {
-			@include oColorsSetUseCase(test-case, text, 'candy');
+			@include oColorsSetUseCase('o-colors', 'test-case', (
+				'text': 'candy'
+			));
 			@include assert-equal(oColorsByUsecase(test-case, text), ('candy'));
+		};
+		@include it('override a default o-colors custom use case property') {
+			@include oColorsSetUseCase('o-colors', 'page', (
+				'background': 'candy'
+			));
+			@include assert-equal(oColorsByUsecase('page', 'background'), ('candy'));
 		};
 	};
 
 	@include describe('oColorsFor') {
 		@include test('outputs property declarations for all defined properties for a use case') {
-			@include oColorsSetUseCase(test-color, text, 'jade');
-			@include oColorsSetUseCase(test-color, background, 'wheat');
-			@include oColorsSetUseCase(test-color, outline, 'crimson');
+			@include oColorsSetUseCase('o-colors', 'test-color', (
+				text: 'jade'
+			));
+			@include oColorsSetUseCase('o-colors', 'test-color', (
+				background: 'wheat'
+			));
+			@include oColorsSetUseCase('o-colors', 'test-color', (
+				outline: 'crimson'
+			));
 			@include assert() {
 				@include output($selector: false) {
 					.test-colors {


### PR DESCRIPTION
**You may want to review just [the first commit](https://github.com/Financial-Times/o-colors/pull/211/commits/3e48989124b7df3275ecd867381ef6125e2e00a0) the latter was merged from [this approved pr](https://github.com/Financial-Times/o-colors/pull/212).**

Updates `oColorsSetUseCase`:
- Adds explicit usecase namespace.
- Adds support for granular usecase property deprecation.
- Errors when setting a usecase which already exists, outside
o-colors defaults which may be overridden.

Updates `oColorsSetColor`:
- Erros when setting a colour which already exists, outside
o-colors defaults which ma be overridden.

Removes variable `$o-colors-branded-usecases`.

Makes demos quiet (hides ignored contrast warnings).