### PR TITLE
Set default usecase and palette colours consistently.

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -14,7 +14,8 @@
 @import 'src/scss/mixins';
 
 // Set the palette colors programatically
-@include _oColorsSetPaletteColors;
+@include _oColorsSetDefaultPaletteColors;
+@include _oColorsSetDefaultUsecases;
 @include _oColorsSetPaletteTints;
 
 /// Output `o-colors` CSS classes and custom properties.

--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -31,7 +31,7 @@
 	$deprecated: map-get($meta, 'deprecated');
 	$already-warned: index($_o-colors-deprecation-warnings-output, $namespaced-color-name) != null;
 	@if $deprecated and not $already-warned {
-		$deprecation-message: 'The color "#{$color-name}" from "#{$from}" is deprecated for the "#{$_o-colors-brand}" palette, and will be removed in the next major.';
+		$deprecation-message: 'The color "#{$color-name}" from "#{$from}" is deprecated for the "#{oBrandGetCurrentBrand()}" palette, and will be removed in the next major.';
 		// Append any custom deprecation message.
 		$deprecation-message: if(type-of($deprecated) != 'string', $deprecation-message, $deprecation-message + ' ' + $deprecated);
 		// Output warning.

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -199,12 +199,19 @@
 	}
 }
 
-/// Update the palette with default o-colors palette colours.
-@mixin _oColorsSetPaletteColors {
-	@each $color-name, $color-details in $_o-colors-default-palette-colors {
-		$color-hex: map-get($color-details, 'color');
-		$opts: map-get($color-details, 'opts');
+/// Add default o-colors palette colours.
+@mixin _oColorsSetDefaultPaletteColors {
+	@each $color-name, $color-hex, $opts in $_o-colors-default-palette-colors {
+		$opts: if($opts, $opts, ());
 		@include oColorsSetColor('o-colors', $color-name, $color-hex, $opts);
+	}
+}
+
+/// Add default o-colors usecases.
+@mixin _oColorsSetDefaultUsecases {
+	@each $usecase, $colors, $opts in $_o-colors-default-usecases {
+		$opts: if($opts, $opts, ());
+		@include oColorsSetUseCase('o-colors', $usecase, $colors, $opts);
 	}
 }
 

--- a/src/scss/_palette.scss
+++ b/src/scss/_palette.scss
@@ -1,107 +1,107 @@
 // Define universal primary palette.
-$_o-colors-default-palette-colors: map-merge((
-	'black':                 ('color': #000000, 'opts': ()),
-	'white':                 ('color': #ffffff, 'opts': ()),
+$_o-colors-default-palette-colors: join((
+	('black', #000000),
+	('white', #ffffff),
 ), $_o-colors-default-palette-colors);
 
 // Master brand palette.
-@if $_o-colors-brand == master {
-	$_o-colors-default-palette-colors: map-merge((
+@if oBrandGetCurrentBrand() == master {
+	$_o-colors-default-palette-colors: join((
 		// primary palette
-		'paper':                 ('color': #fff1e5, 'opts': ()),
-		'claret':                ('color': #990f3d, 'opts': ()),
-		'oxford':                ('color': #0f5499, 'opts': ()),
-		'teal':                  ('color': #0d7680, 'opts': ()),
+		('paper', #fff1e5),
+		('claret', #990f3d),
+		('oxford', #0f5499),
+		('teal', #0d7680),
 
 		//secondary palette
-		'wheat':                 ('color': #f2dfce, 'opts': ()),
-		'sky':                   ('color': #cce6ff, 'opts': ()),
-		'slate':                 ('color': #262a33, 'opts': ()),
-		'velvet':                ('color': #593380, 'opts': ()),
-		'mandarin':              ('color': #ff8833, 'opts': ()),
-		'lemon':                 ('color': #ffec1a, 'opts': ()),
+		('wheat', #f2dfce),
+		('sky', #cce6ff),
+		('slate', #262a33),
+		('velvet', #593380),
+		('mandarin', #ff8833),
+		('lemon', #ffec1a),
 
 		//tertiary palette
-		'candy':                 ('color': #ff7faa, 'opts': ()),
-		'wasabi':                ('color': #96cc28, 'opts': ()),
-		'jade':                  ('color': #00994d, 'opts': ()),
-		'crimson':               ('color': #cc0000, 'opts': ()),
+		('candy', #ff7faa),
+		('wasabi', #96cc28),
+		('jade', #00994d),
+		('crimson', #cc0000),
 
 		//b2c palette
-		'org-b2c':               ('color': #4e96eb, 'opts': ()),
-		'org-b2c-dark':          ('color': #3a70af, 'opts': ()),
-		'org-b2c-light':         ('color': #99c6fb, 'opts': ()),
+		('org-b2c', #4e96eb),
+		('org-b2c-dark', #3a70af),
+		('org-b2c-light', #99c6fb),
 	), $_o-colors-default-palette-colors);
 }
 
 // Internal brand palette.
-@if $_o-colors-brand == internal {
-	$_o-colors-default-palette-colors: map-merge((
+@if oBrandGetCurrentBrand() == internal {
+	$_o-colors-default-palette-colors: join((
 		// primary palette
-		'oxford':         ('color': #0f5499, 'opts': ()),
-		'teal':           ('color': #0d7680, 'opts': ()),
-		'paper':          ('color': #fff1e5, 'opts': ('deprecated': true)),
-		'claret':         ('color': #990f3d, 'opts': ('deprecated': true)),
+		('oxford', #0f5499),
+		('teal', #0d7680),
+		('paper', #fff1e5, ('deprecated': true)),
+		('claret', #990f3d, ('deprecated': true)),
 
 		//secondary palette
-		'lemon':          ('color': #ffec1a, 'opts': ()),
-		'slate':          ('color': #262a33, 'opts': ()),
-		'wheat':          ('color': #f2dfce, 'opts': ('deprecated': true)),
-		'sky':            ('color': #cce6ff, 'opts': ('deprecated': true)),
-		'velvet':         ('color': #593380, 'opts': ('deprecated': true)),
-		'mandarin':       ('color': #ff8833, 'opts': ('deprecated': true)),
+		('lemon', #ffec1a),
+		('slate', #262a33),
+		('wheat', #f2dfce, ('deprecated': true)),
+		('sky', #cce6ff, ('deprecated': true)),
+		('velvet', #593380, ('deprecated': true)),
+		('mandarin', #ff8833, ('deprecated': true)),
 
 		//tertiary palette
-		'jade':           ('color': #00994d, 'opts': ()),
-		'crimson':        ('color': #cc0000, 'opts': ()),
-		'candy':          ('color': #ff7faa, 'opts': ('deprecated': true)),
-		'wasabi':         ('color': #96cc28, 'opts': ('deprecated': true)),
+		('jade', #00994d),
+		('crimson', #cc0000),
+		('candy', #ff7faa, ('deprecated': true)),
+		('wasabi', #96cc28, ('deprecated': true)),
 
 		//b2c palette
-		'org-b2c':        ('color': #4e96eb, 'opts': ('deprecated': true)),
-		'org-b2c-dark':   ('color': #3a70af, 'opts': ('deprecated': true)),
-		'org-b2c-light':  ('color': #99c6fb, 'opts': ('deprecated': true)),
+		('org-b2c', #4e96eb, ('deprecated': true)),
+		('org-b2c-dark', #3a70af, ('deprecated': true)),
+		('org-b2c-light', #99c6fb, ('deprecated': true)),
 	), $_o-colors-default-palette-colors);
 
 	// Add experimental colors to support work on the internal brand design.
-	$_o-colors-default-palette-colors: map-merge((
-		'slate-white-15': ('color': #dedfe0, 'opts': ()), // oColorsMix('slate', 'white', 15): to support work on internal brand design
-		'slate-white-5':  ('color': #f4f4f5, 'opts': ()), // oColorsMix('slate', 'white', 5): to support work on internal brand design
+	$_o-colors-default-palette-colors: join((
+		('slate-white-15', #dedfe0), // oColorsMix('slate', 'white', 15): to support work on internal brand design
+		('slate-white-5', #f4f4f5), // oColorsMix('slate', 'white', 5): to support work on internal brand design
 	), $_o-colors-default-palette-colors);
 }
 
 // Whitelabel brand palette.
-@if $_o-colors-brand == whitelabel {
-	$_o-colors-default-palette-colors: map-merge((
+@if oBrandGetCurrentBrand() == whitelabel {
+	$_o-colors-default-palette-colors: join((
 		// primary palette
-		'oxford':         ('color': #0f5499, 'opts': ('deprecated': true)),
-		'teal':           ('color': #0d7680, 'opts': ('deprecated': true)),
-		'paper':          ('color': #fff1e5, 'opts': ('deprecated': true)),
-		'claret':         ('color': #990f3d, 'opts': ('deprecated': true)),
+		('oxford', #0f5499, ('deprecated': true)),
+		('teal', #0d7680, ('deprecated': true)),
+		('paper', #fff1e5, ('deprecated': true)),
+		('claret', #990f3d, ('deprecated': true)),
 
 		//secondary palette
-		'lemon':          ('color': #ffec1a, 'opts': ('deprecated': true)),
-		'slate':          ('color': #262a33, 'opts': ('deprecated': true)),
-		'wheat':          ('color': #f2dfce, 'opts': ('deprecated': true)),
-		'sky':            ('color': #cce6ff, 'opts': ('deprecated': true)),
-		'velvet':         ('color': #593380, 'opts': ('deprecated': true)),
-		'mandarin':       ('color': #ff8833, 'opts': ('deprecated': true)),
+		('lemon', #ffec1a, ('deprecated': true)),
+		('slate', #262a33, ('deprecated': true)),
+		('wheat', #f2dfce, ('deprecated': true)),
+		('sky', #cce6ff, ('deprecated': true)),
+		('velvet', #593380, ('deprecated': true)),
+		('mandarin', #ff8833, ('deprecated': true)),
 
 		//tertiary palette
-		'jade':           ('color': #00994d, 'opts': ('deprecated': true)),
-		'crimson':        ('color': #cc0000, 'opts': ('deprecated': true)),
-		'candy':          ('color': #ff7faa, 'opts': ('deprecated': true)),
-		'wasabi':         ('color': #96cc28, 'opts': ('deprecated': true)),
+		('jade', #00994d, ('deprecated': true)),
+		('crimson', #cc0000, ('deprecated': true)),
+		('candy', #ff7faa, ('deprecated': true)),
+		('wasabi', #96cc28, ('deprecated': true)),
 
 		//b2c palette
-		'org-b2c':        ('color': #4e96eb, 'opts': ('deprecated': true)),
-		'org-b2c-dark':   ('color': #3a70af, 'opts': ('deprecated': true)),
-		'org-b2c-light':  ('color': #99c6fb, 'opts': ('deprecated': true)),
+		('org-b2c', #4e96eb, ('deprecated': true)),
+		('org-b2c-dark', #3a70af, ('deprecated': true)),
+		('org-b2c-light', #99c6fb, ('deprecated': true)),
 	), $_o-colors-default-palette-colors);
 }
 
 // Master brand palette tints.
-@if $_o-colors-brand == master {
+@if oBrandGetCurrentBrand() == master {
 	$o-colors-tints: map-merge((
 		'black': (
 			tints: (5, 10, 20, 30, 40, 50, 60, 70, 80, 90),
@@ -168,7 +168,7 @@ $_o-colors-default-palette-colors: map-merge((
 }
 
 // Internal brand palette tints.
-@if $_o-colors-brand == internal {
+@if oBrandGetCurrentBrand() == internal {
 	$o-colors-tints: map-merge((
 		'black': (
 			tints: (5, 10, 20, 30, 40, 50, 60, 70, 80, 90),
@@ -242,7 +242,7 @@ $_o-colors-default-palette-colors: map-merge((
 }
 
 // Whitelabel brand palette tints.
-@if $_o-colors-brand == whitelabel {
+@if oBrandGetCurrentBrand() == whitelabel {
 	$o-colors-tints: map-merge((
 		'black': (
 			tints: (5, 10, 20, 30, 40, 50, 60, 70, 80, 90),

--- a/src/scss/_use-cases.scss
+++ b/src/scss/_use-cases.scss
@@ -1,74 +1,93 @@
-////
-/// @group o-colors
-/// @link http://registry.origami.ft.com/components/o-colors
-////
-
-/// color use cases
-///
-/// These mappings define what we use our colors for.
-///
-/// Use case:           Must be a single word comprising just letters, numbers, and dashes.
-/// Properties:         A Sass map of colours `colors` and options `opts`.
-/// Properties-colors:  A Sass map of properties (must be 'border', 'text', 'background', 'outline', or 'all')
-///                     against palette colors (must be an exact match for a name of a color defined
-///                     in palette.scss).
-/// Properties-opts:    A Sass map of options. May include a 'deprecated' key with a deprecation message for
-///						the usecase, or a map of deprecation messages for each usecase property.
-///						E.g. `('deprecated': 'this usecase is not used anymore.')`
-///						E.g. `('deprecated': ('border': 'this usecase has no border property anymore'))`
-///
-/// @type map
-$_o-colors-branded-usecases: (
-	'master': (
-		//	<use case>						<properties>
-		o-colors-focus:						('colors': (outline: 'black-50'), 'opts': ()),
-		o-colors-page:						('colors': (background: 'paper'), 'opts': ()),
-		o-colors-box:						('colors': (background: 'wheat'), 'opts': ()),
-		o-colors-link:						('colors': (text: 'teal'), 'opts': ()),
-		o-colors-link-hover:				('colors': (text: 'teal-30'), 'opts': ()),
-		o-colors-link-title:				('colors': (text: 'black-80'), 'opts': ()),
-		o-colors-link-title-hover:			('colors': (text: 'black-70'), 'opts': ()),
-		o-colors-tag-link:					('colors': (text: 'claret'), 'opts': ()),
-		o-colors-tag-link-hover:			('colors': (text: 'claret-30'), 'opts': ()),
-		o-colors-opinion-tag-link:			('colors': (text: 'oxford'), 'opts': ()),
-		o-colors-opinion-tag-link-hover:	('colors': (text: 'oxford-30'), 'opts': ()),
-		o-colors-title:						('colors': (text: 'black'), 'opts': ()),
-		o-colors-body:						('colors': (text: 'black-80'), 'opts': ()),
-		o-colors-muted:						('colors': (text: 'black-20'), 'opts': ()),
-		o-colors-opinion:					('colors': (background: 'sky'), 'opts': ()),
-		o-colors-hero:						('colors': (background: 'wheat'), 'opts': ()),
-		o-colors-hero-opinion:				('colors': (background: 'oxford'), 'opts': ()),
-		o-colors-hero-highlight:			('colors': (background: 'claret'), 'opts': ()),
+@if oBrandGetCurrentBrand() == master {
+	$_o-colors-default-usecases: (
+		('focus', ('outline': 'black-50')),
+		('page', ('background': 'paper')),
+		('box', ('background': 'wheat')),
+		('link', ('text': 'teal')),
+		('link-hover', ('text': 'teal-30')),
+		('link-title', ('text': 'black-80')),
+		('link-title-hover', ('text': 'black-70')),
+		('tag-link', ('text': 'claret')),
+		('tag-link-hover', ('text': 'claret-30')),
+		('opinion-tag-link', ('text': 'oxford')),
+		('opinion-tag-link-hover', ('text': 'oxford-30')),
+		('title', ('text': 'black')),
+		('body', ('text': 'black-80')),
+		('muted', ('text': 'black-20')),
+		('opinion', ('background': 'sky')),
+		('hero', ('background': 'wheat')),
+		('hero-opinion', ('background': 'oxford')),
+		('hero-highlight', ('background': 'claret')),
 
 		// Section colors
-		o-colors-section-life-arts:			('colors': (all: 'velvet'), 'opts': ()),
-		o-colors-section-life-arts-alt:		('colors': (all: 'candy'), 'opts': ()),
-		o-colors-section-magazine:			('colors': (all: 'oxford'), 'opts': ()),
-		o-colors-section-magazine-alt:		('colors': (all: 'sky'), 'opts': ()),
-		o-colors-section-house-home:		('colors': (all: 'jade'), 'opts': ()),
-		o-colors-section-house-home-alt:	('colors': (all: 'wasabi'), 'opts': ()),
-		o-colors-section-money:				('colors': (all: 'crimson'), 'opts': ()),
-		o-colors-section-money-alt:			('colors': (all: 'white'), 'opts': ()),
-	),
-	'internal': (
-		//	<use case>						<properties>
-		o-colors-focus:						('colors': (outline: 'oxford-80'), 'opts': ()),
-		o-colors-page:						('colors': (background: 'white'), 'opts': ()),
-		o-colors-box:						('colors': (background: 'slate-white-5'), 'opts': ()),
-		o-colors-link:						('colors': (text: 'teal'), 'opts': ()),
-		o-colors-link-hover:				('colors': (text: 'teal-30'), 'opts': ()),
-		o-colors-link-title:				('colors': (text: 'slate-white-15'), 'opts': ()),
-		o-colors-link-title-hover:			('colors': (text: 'slate-white-15'), 'opts': ()),
-		o-colors-title:						('colors': (text: 'slate'), 'opts': ()),
-		o-colors-body:						('colors': (text: 'slate'), 'opts': ()),
-		o-colors-muted:						('colors': (text: 'black-20'), 'opts': ()),
-	),
-	'whitelabel': (
-		//	<use case>						<properties>
-		o-colors-page:						('colors': (background: 'white'), 'opts': ()),
-	)
-);
+		('section-life-arts', (
+			'text': 'velvet',
+			'background': 'velvet',
+			'border': 'velvet',
+			'outline': 'velvet'
+		)),
+		('section-life-arts-alt', (
+			'text': 'candy',
+			'background': 'candy',
+			'border': 'candy',
+			'outline': 'candy'
+		)),
+		('section-magazine', (
+			'text': 'oxford',
+			'background': 'oxford',
+			'border': 'oxford',
+			'outline': 'oxford'
+		)),
+		('section-magazine-alt', (
+			'text': 'sky',
+			'background': 'sky',
+			'border': 'sky',
+			'outline': 'sky'
+		)),
+		('section-house-home', (
+			'text': 'jade',
+			'background': 'jade',
+			'border': 'jade',
+			'outline': 'jade'
+		)),
+		('section-house-home-alt', (
+			'text': 'wasabi',
+			'background': 'wasabi',
+			'border': 'wasabi',
+			'outline': 'wasabi'
+		)),
+		('section-money', (
+			'text': 'crimson',
+			'background': 'crimson',
+			'border': 'crimson',
+			'outline': 'crimson'
+		)),
+		('section-money-alt', (
+			'text': 'white',
+			'background': 'white',
+			'border': 'white',
+			'outline': 'white'
+		)),
+	);
+};
 
-$_o-colors-default-brand-usecases: map-get($_o-colors-branded-usecases, 'master');
-$_o-colors-current-brand-usecases: map-get($_o-colors-branded-usecases, $_o-colors-brand);
-$_o-colors-usecases: map-merge(if($_o-colors-current-brand-usecases, $_o-colors-current-brand-usecases, $_o-colors-default-brand-usecases), $_o-colors-usecases);
+@if oBrandGetCurrentBrand() == internal {
+	$_o-colors-default-usecases: (
+		('focus', ('outline': 'oxford-80')),
+		('page', ('background': 'white')),
+		('box', ('background': 'slate-white-5')),
+		('link', ('text': 'teal')),
+		('link-hover', ('text': 'teal-30')),
+		('link-title', ('text': 'slate-white-15')),
+		('link-title-hover', ('text': 'slate-white-15')),
+		('title', ('text': 'slate')),
+		('body', ('text': 'slate')),
+		('muted', ('text': 'black-20')),
+	);
+};
+
+@if oBrandGetCurrentBrand() == whitelabel {
+	$_o-colors-default-usecases: (
+		('page', ('background': 'white')),
+	);
+};

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -1,22 +1,27 @@
 $o-colors-is-silent: true !default;
 
-/// Brand to define colours conditionally.
+/// A list of arguments for `oColorsSetColor`, except the project name. Used
+/// to set default palette colours.
 ///
-/// @type String
-$_o-colors-brand: oBrandGetCurrentBrand();
-
-/// Default FT colours to add to the colour palette.
-/// @prop {Map}
-/// @prop {Map} base.color-name - Where `color-name` is the name of the colour, e.g. paper.
-/// @prop {Color} base.color-name.color - The color for the colour name.
-/// @prop {Map} base.color-name.opts - Extra details about the colour.
-/// @prop {String|Boolean} base.color-name.opts.deprecated - True, or a deprecation message, if the colour is deprecated.
+/// @see _oColorsSetDefaultPaletteColors
+/// @see oColorsSetColor
+///
+/// @type list
 $_o-colors-default-palette-colors: () !default;
 
-$_o-colors-palette: () !default;
-$o-colors-tints: ();
+/// A list of arguments for `oColorsSetUseCase`, except the project name. Used
+/// to set default usecases.
+///
+/// @see _oColorsSetDefaultUsecases
+/// @see oColorsSetUseCase
+///
+/// @type list
+$_o-colors-default-usecases: () !default;
+
 
 $_o-colors-usecases: () !default;
+$_o-colors-palette: () !default;
+$o-colors-tints: ();
 
 // These are common usecase which are not necessarily defined for each brand.
 // When the usecase is used and `null` is returned, there is no need to warn about it.


### PR DESCRIPTION
Default usecase and palette colour variables now contain a list of args
for use with mixins. This is simpler than maintaining the structure of
the map used to store set usecases and palette colours manually.