### PR TITLE
Update `oColorsGetTextColor`.

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -70,18 +70,18 @@ The name of the first argument of `oColorsGetTextColor` has changed. It was `$ba
 +	color: oColorsGetTextColor($background: 'paper');
 ```
 
-`oColorsGetTextColor` now errors if the contrast between the given background and text colour does not pass WCAG 2.1 level AA for [normal text](https://www.w3.org/TR/WCAG21/#contrast-minimum). Previously it would only throw a warning provided the contrast check passed for [large text](https://www.w3.org/TR/WCAG21/#dfn-large-scale). Accordingly, the third `$warnings` argument is now `$minimum-contrast`. It accepts a number, the minimum contrast allowed between the given background and the returned text colour. To migrate update the third `$warnings` argument of `oColorsGetTextColor` to `$minimum-contrast`:
-- **not set**: no changes are needed unless contrast errors are thrown. If an error is thrown set to `3`, to error if the colour contrast is not enough for [large text](https://www.w3.org/TR/WCAG21/#dfn-large-scale), or `null` to ignore the contrast of the resulting text colour.
+`oColorsGetTextColor` now errors if the contrast between the given background and text colour does not pass WCAG 2.1 level AA for [normal text](https://www.w3.org/TR/WCAG21/#contrast-minimum). Previously it would only throw a warning provided the contrast check passed for [large text](https://www.w3.org/TR/WCAG21/#dfn-large-scale). Accordingly, the third `$warnings` argument is now `$minimum-contrast`. This can be set to one of `aa-normal` (default), `aa-large`, `aaa-normal`, `aaa-large`, or `null` to remove the contrast check. To migrate update the third `$warnings` argument of `oColorsGetTextColor` to `$minimum-contrast`:
+- **not set**: no changes are needed unless contrast errors are thrown. If an error is thrown set `$minimum-contrast` to `aa-large` if creating a colour for [large text](https://www.w3.org/TR/WCAG21/#dfn-large-scale), or `null` to ignore the contrast of the resulting text colour. Only ignore contrast errors for [incidental or logo text](https://www.w3.org/TR/WCAG21/#contrast-minimum), otherwise your project may be inaccessible.
 - **true**: remove the argument, it's optional and checks contrast for [normal text](https://www.w3.org/TR/WCAG21/#contrast-minimum) by default. If a contrast error is thrown refer to the point "not set" above.
 - **false**: set to `null` instead.
 
 E.g. If generating a colour for [large text](https://www.w3.org/TR/WCAG21/#dfn-large-scale), error if the contrast between the background `paper` is lower than 3:1 (see [WCAG 2.1](https://www.w3.org/TR/WCAG21/#contrast-minimum))
 ```diff
 -	color: oColorsGetTextColor('paper', 80, $warnings: false);
-+	color: oColorsGetTextColor('paper', 80, $minimum-contrast: 3);
++	color: oColorsGetTextColor('paper', 80, $minimum-contrast: 'aa-large');
 ```
 
-Or set to `null` to never error, regardless of the contrast between the given background `paper` and the result:
+Or set to `null` to never error, e.g. for [incidental or logo text](https://www.w3.org/TR/WCAG21/#contrast-minimum), regardless of the contrast between the given background `paper` and the result:
 ```diff
 -	color: oColorsGetTextColor($backgroundd: 'paper', $warnings: false);
 +	color: oColorsGetTextColor($background': paper', $minimum-contrast: null);

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -61,6 +61,32 @@ As `o-colors` [no longer outputs usecase CSS classes](#MIGRATION.md#migrating-fr
 ));
 ```
 
+#### oColorsGetTextColor
+
+The name of the first argument of `oColorsGetTextColor` has changed. It was `$backgroundd` (with a double `d`) but it now spelled correctly as `$background`. E.g:
+
+```diff
+-	color: oColorsGetTextColor($backgroundd: 'paper');
++	color: oColorsGetTextColor($background: 'paper');
+```
+
+`oColorsGetTextColor` now errors if the contrast between the given background and text colour does not pass WCAG 2.1 level AA for [normal text](https://www.w3.org/TR/WCAG21/#contrast-minimum). Previously it would only throw a warning provided the contrast check passed for [large text](https://www.w3.org/TR/WCAG21/#dfn-large-scale). Accordingly, the third `$warnings` argument is now `$minimum-contrast`. It accepts a number, the minimum contrast allowed between the given background and the returned text colour. To migrate update the third `$warnings` argument of `oColorsGetTextColor` to `$minimum-contrast`:
+- **not set**: no changes are needed unless contrast errors are thrown. If an error is thrown set to `3`, to error if the colour contrast is not enough for [large text](https://www.w3.org/TR/WCAG21/#dfn-large-scale), or `null` to ignore the contrast of the resulting text colour.
+- **true**: remove the argument, it's optional and checks contrast for [normal text](https://www.w3.org/TR/WCAG21/#contrast-minimum) by default. If a contrast error is thrown refer to the point "not set" above.
+- **false**: set to `null` instead.
+
+E.g. If generating a colour for [large text](https://www.w3.org/TR/WCAG21/#dfn-large-scale), error if the contrast between the background `paper` is lower than 3:1 (see [WCAG 2.1](https://www.w3.org/TR/WCAG21/#contrast-minimum))
+```diff
+-	color: oColorsGetTextColor('paper', 80, $warnings: false);
++	color: oColorsGetTextColor('paper', 80, $minimum-contrast: 3);
+```
+
+Or set to `null` to never error, regardless of the contrast between the given background `paper` and the result:
+```diff
+-	color: oColorsGetTextColor($backgroundd: 'paper', $warnings: false);
++	color: oColorsGetTextColor($background': paper', $minimum-contrast: null);
+```
+
 #### oColorsByUsecase
 
 `oColorsGetUseCase` is now `oColorsByUsecase`. By default `oColorsByUsecase` now errors if a usecase isn't found, unless a `$fallback` colour has been given (which may be `null`). A list of usecases are no longer accepted. `oColorsByUsecase` also has a new `$from` argument, to get usecases set by different component or projects.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ You can create tints of a color with the [`oColorsGetTint`](#tint-palette-colors
 
 To work with text colors the [`oColorsFor`](#use-case-mixin) mixin and [`oColorsGetTextColor`](#generated-text-colors) function will output a text color based on the background color, which will be a mix of either black or white with the background at the percentage requested. You can also mix two colors manually using the [`oColorsMix`](#mix-colors) function, providing two colors (either hex or palette color names) and a percentage at which to mix them.
 
-When working with the `oColorsFor` and `oColorsGetTextColor` features, the Sass will also automatically test the background color with the generated text color to see if the combination passes Web Content Accessibility Guidelines (WCAG). If the combination fails to pass at least WCAG AA you will see an error, if the combination passes AA but only at a larger font size (18px+), there will be a warning.
+When working with the `oColorsFor` and `oColorsGetTextColor` features, the Sass will also automatically test the background color with the generated text color to see if the combination passes Web Content Accessibility Guidelines (WCAG). If the combination fails to pass at least WCAG AA you will see an error.
 
 For manually testing color contrasts, you can use [Lea Verou's Contrast Ratio tool](http://leaverou.github.io/contrast-ratio/).
 

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -29,7 +29,7 @@ body {
 
 	.o-colors-palette-#{$name} .hex,
 	.o-colors-palette-#{$name}:after {
-		color: oColorsGetTextColor($name, 95,  $warnings: false);
+		color: oColorsGetTextColor($name, 95, $minimum-contrast: null);
 	}
 }
 

--- a/main.scss
+++ b/main.scss
@@ -43,7 +43,7 @@
 				background-color: oColorsByName($name);
 
 				@if $name != 'transparent' and $name != 'inherit' {
-					color: oColorsGetTextColor($name, 100, $warnings: false);
+					color: oColorsGetTextColor($name, 100, $minimum-contrast: null);
 				}
 			}
 		}

--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -237,34 +237,42 @@
 /// Returns a text color based on the background and
 /// an opacity percentage the color should appear at
 ///
-/// @param {Color} $background - the hex color of the background the text will appear on
+/// @param {Color} $background - the palette name or hex of the background the text will appear on
 /// @param {Number} $opacity [100] - the opacity percentage the text color should appear at
-/// @param {Boolean} $warnings [true] - whether this function should throw WCAG contrast check warnings/errors
-@function oColorsGetTextColor($backgroundd, $opacity: 90, $warnings: true) {
-	$background: if(type-of($backgroundd) == 'string', oColorsByName($backgroundd), $backgroundd);
+/// @param {Number|Null} $minimum-contrast [4.5] - the minimum contrast ratio between the background and the returned text color. If the contrast ratio is lower an error is thrown. WCAG 2.1 level AA requires a contrast ratio of at least 4.5:1 for normal text and 3:1 for large text. Set to `null` to not throw an error.
+@function oColorsGetTextColor($background, $opacity: 90, $minimum-contrast: 4.5) {
+	// Get background hex if palette colour name has been given.
+	$background-name: $background;
+	$background: if(type-of($background) == 'string', oColorsByName($background), $background);
 
-	@if $background == null or type-of($background) != color {
+	// Validate argument types.
+	@if type-of($background) != color {
 		@return _error("'#{inspect($background)}' is not a valid color. To get a text color, please supply a valid hex code or color name for the background color'");
 	}
-
-	$percentage: $opacity;
-	$baseColor: _oColorsGetTextBase($background);
-	$textColor: oColorsMix($baseColor, $background, $percentage);
-	$testContrast: oColorsCheckContrast($textColor, $background, false);
-
-	@if not $testContrast {
-		$baseColor: if($baseColor == 'black', 'white', 'black');
-		$textColor: oColorsMix($baseColor, $background, $percentage);
-		$testContrast: oColorsCheckContrast($textColor, $background, false);
+	@if type-of($opacity) != 'number' {
+		@return _error("'#{inspect($opacity)}' is not a valid opacity, set to a number.'");
+	}
+	@if $minimum-contrast != null and type-of($minimum-contrast) != 'number' {
+		@return _error("'#{inspect($minimum-contrast)}' is not a valid minimum contrast. Set to a number or `null` to ignore the contrast ratio of the resulting text colour and background.'");
 	}
 
-	@if not $testContrast and $warnings == true {
-		@return _error("The combination of #{$opacity}% #{$baseColor} on #{$background} does not pass WCAG guidelines for color contrast.");
+	// Calculate text colour for background and opacity.
+	$base-color: if(oColorsColorBrightness($background) > 35%, 'black', 'white');
+	$text-color: oColorsMix($base-color, $background, $opacity);
+
+	// Check text/background contrast ratio.
+	$contrast-ratio: oColorsGetContrastRatio($text-color, $background);
+	@if $minimum-contrast != null and $contrast-ratio < $minimum-contrast {
+		@return _error(
+			"The text colour for #{inspect($background-name)} at " +
+			"#{inspect($opacity)}% opacity has a contrast ratio of " +
+			"\"#{inspect($contrast-ratio)}\" and does not pass " +
+			if($minimum-contrast == 4.5, "the WCAG 2.1 level AA " +
+			"required contrast ratio of at least 4.5:1 for normal text. ",
+			"have a contrast ratio of at least \"#{inspect($minimum-contrast)}\". ") +
+			"Set the `$minimum-contrast` argument if a lower contrast is acceptable."
+		);
 	}
 
-	@if $testContrast == 'large' and $warnings == true {
-		@warn "When using this combination (#{$opacity}% #{$baseColor} on #{$background}) please use a font size larger than 18px.";
-	}
-
-	@return $textColor;
+	@return $text-color;
 }

--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -239,38 +239,49 @@
 ///
 /// @param {Color} $background - the palette name or hex of the background the text will appear on
 /// @param {Number} $opacity [100] - the opacity percentage the text color should appear at
-/// @param {Number|Null} $minimum-contrast [4.5] - the minimum contrast ratio between the background and the returned text color. If the contrast ratio is lower an error is thrown. WCAG 2.1 level AA requires a contrast ratio of at least 4.5:1 for normal text and 3:1 for large text. Set to `null` to not throw an error.
-@function oColorsGetTextColor($background, $opacity: 90, $minimum-contrast: 4.5) {
+/// @param {String|Null} $minimum-contrast ['aa-normal'] - the minimum contrast ratio standard between the background and the returned text color, one of: aa-normal, aa-large, aaa-normal, aaa-large. See [WCAG 2.1 guidelines](https://www.w3.org/TR/WCAG21/#contrast-minimum). If the contrast ratio is too low to meet the selected guideline an error is thrown. Set to `null` to remove contrast checking and never throw an error.
+@function oColorsGetTextColor($background, $opacity: 90, $minimum-contrast: 'aa-normal') {
 	// Get background hex if palette colour name has been given.
 	$background-name: $background;
 	$background: if(type-of($background) == 'string', oColorsByName($background), $background);
 
-	// Validate argument types.
+	// Contrast values. See https://www.w3.org/TR/WCAG21/#contrast-minimum
+	$contrast-levels: (
+		'aa-normal': 4.5,
+		'aa-large': 3,
+		'aaa-normal': 7,
+		'aaa-large': 4.5
+	);
+
+	// Validate arguments.
+	@if($minimum-contrast != null and not map-has-key($contrast-levels, $minimum-contrast)) {
+		@return _error('The minimum contrast must by one of "#{map-keys($contrast-levels)}" '+
+		'or `null`. Found "#{inspect($minimum-contrast)}".');
+	}
+
 	@if type-of($background) != color {
 		@return _error("'#{inspect($background)}' is not a valid color. To get a text color, please supply a valid hex code or color name for the background color'");
 	}
+
 	@if type-of($opacity) != 'number' {
 		@return _error("'#{inspect($opacity)}' is not a valid opacity, set to a number.'");
 	}
-	@if $minimum-contrast != null and type-of($minimum-contrast) != 'number' {
-		@return _error("'#{inspect($minimum-contrast)}' is not a valid minimum contrast. Set to a number or `null` to ignore the contrast ratio of the resulting text colour and background.'");
-	}
 
 	// Calculate text colour for background and opacity.
+	$required-contrast-ratio: map-get($contrast-levels, $minimum-contrast);
 	$base-color: if(oColorsColorBrightness($background) > 35%, 'black', 'white');
 	$text-color: oColorsMix($base-color, $background, $opacity);
 
 	// Check text/background contrast ratio.
 	$contrast-ratio: oColorsGetContrastRatio($text-color, $background);
-	@if $minimum-contrast != null and $contrast-ratio < $minimum-contrast {
+	@if $minimum-contrast != null and $contrast-ratio < $required-contrast-ratio {
 		@return _error(
-			"The text colour for #{inspect($background-name)} at " +
-			"#{inspect($opacity)}% opacity has a contrast ratio of " +
-			"\"#{inspect($contrast-ratio)}\" and does not pass " +
-			if($minimum-contrast == 4.5, "the WCAG 2.1 level AA " +
-			"required contrast ratio of at least 4.5:1 for normal text. ",
-			"have a contrast ratio of at least \"#{inspect($minimum-contrast)}\". ") +
-			"Set the `$minimum-contrast` argument if a lower contrast is acceptable."
+			'The text colour generated for #{inspect($background-name)} at ' +
+			'#{inspect($opacity)}% opacity has a contrast ratio of ' +
+			'"#{inspect($contrast-ratio)}" and does not pass the WCAG 2.1 ' +
+			'#{$minimum-contrast} required contrast ratio of at least ' +
+			'#{$required-contrast-ratio}:1. Update the `$minimum-contrast` argument ' +
+			'if a lower contrast is acceptable.'
 		);
 	}
 

--- a/src/scss/tools/_a11y.scss
+++ b/src/scss/tools/_a11y.scss
@@ -1,15 +1,3 @@
-/// Return either white or black for the text base
-/// depending on the background color
-///
-/// @param {String} $color - the name of the background color being used
-@function _oColorsGetTextBase($color) {
-	@if oColorsColorBrightness($color) < 65% {
-		@return 'white';
-	} @else {
-		@return 'black';
-	}
-}
-
 /// Checks the contrast ratio and returns the WCAG
 /// rating, either AAA, AA, or AA18 meaning text should
 /// be at least 18px

--- a/test/scss/_functions.test.scss
+++ b/test/scss/_functions.test.scss
@@ -111,11 +111,15 @@
 			@include assert-equal(oColorsGetTextColor(oColorsByName('paper')), (#1a1817));
 		};
 		@include it('throws an error if a text color and background does not pass WCAG contrast guidelines') {
-			@include assert-equal(oColorsGetTextColor(oColorsByName('black-40'), 50),
-			('ERROR: The combination of 50% black on #999189 does not pass WCAG guidelines for color contrast.'));
+			@include assert-equal(oColorsGetTextColor('black-40', 50),
+			('ERROR: The text colour for black-40 at 50% opacity has a contrast ratio of "2.87" and does not pass the WCAG 2.1 level AA required contrast ratio of at least 4.5:1 for normal text. Set the `$minimum-contrast` argument if a lower contrast is acceptable.'));
 		};
-		@include it('does not throw an error when a text color and background does not pass WCAG contrast guidelines and warnings are disabled') {
-			@include assert-equal(oColorsGetTextColor(oColorsByName('black-40'), 50, $warnings: false),  #4d4945);
+		@include it('throws an error if a text color and background does not pass a custom contrast ratio check') {
+			@include assert-equal(oColorsGetTextColor('black-40', 50, 3.0),
+			('ERROR: The text colour for black-40 at 50% opacity has a contrast ratio of "2.87" and does not pass have a contrast ratio of at least "3". Set the `$minimum-contrast` argument if a lower contrast is acceptable.'));
+		};
+		@include it('does not throw an error when a text color and background does not pass WCAG contrast guidelines and `$minimum-contrast` is set the `null`') {
+			@include assert-equal(oColorsGetTextColor(oColorsByName('black-40'), 50, $minimum-contrast: null),  #4d4945);
 		};
 	};
 };

--- a/test/scss/_functions.test.scss
+++ b/test/scss/_functions.test.scss
@@ -112,11 +112,15 @@
 		};
 		@include it('throws an error if a text color and background does not pass WCAG contrast guidelines') {
 			@include assert-equal(oColorsGetTextColor('black-40', 50),
-			('ERROR: The text colour for black-40 at 50% opacity has a contrast ratio of "2.87" and does not pass the WCAG 2.1 level AA required contrast ratio of at least 4.5:1 for normal text. Set the `$minimum-contrast` argument if a lower contrast is acceptable.'));
+			('ERROR: The text colour generated for black-40 at 50% opacity has a contrast ratio of "2.87" and does not pass the WCAG 2.1 aa-normal required contrast ratio of at least 4.5:1. Update the `$minimum-contrast` argument if a lower contrast is acceptable.'));
+		};
+		@include it('throws an error for an invalid contrast ratio check') {
+			@include assert-equal(oColorsGetTextColor('black-40', 50, 'aaaaaaaa-large'),
+			('ERROR: The minimum contrast must by one of "aa-normal, aa-large, aaa-normal, aaa-large" or `null`. Found "aaaaaaaa-large".'));
 		};
 		@include it('throws an error if a text color and background does not pass a custom contrast ratio check') {
-			@include assert-equal(oColorsGetTextColor('black-40', 50, 3),
-			('ERROR: The text colour for black-40 at 50% opacity has a contrast ratio of "2.87" and does not pass have a contrast ratio of at least "3". Set the `$minimum-contrast` argument if a lower contrast is acceptable.'));
+			@include assert-equal(oColorsGetTextColor('black-40', 50, 'aa-large'),
+			('ERROR: The text colour generated for black-40 at 50% opacity has a contrast ratio of "2.87" and does not pass the WCAG 2.1 aa-large required contrast ratio of at least 3:1. Update the `$minimum-contrast` argument if a lower contrast is acceptable.'));
 		};
 		@include it('does not throw an error when a text color and background does not pass WCAG contrast guidelines and `$minimum-contrast` is set the `null`') {
 			@include assert-equal(oColorsGetTextColor(oColorsByName('black-40'), 50, $minimum-contrast: null),  #4d4945);

--- a/test/scss/_functions.test.scss
+++ b/test/scss/_functions.test.scss
@@ -115,7 +115,7 @@
 			('ERROR: The text colour for black-40 at 50% opacity has a contrast ratio of "2.87" and does not pass the WCAG 2.1 level AA required contrast ratio of at least 4.5:1 for normal text. Set the `$minimum-contrast` argument if a lower contrast is acceptable.'));
 		};
 		@include it('throws an error if a text color and background does not pass a custom contrast ratio check') {
-			@include assert-equal(oColorsGetTextColor('black-40', 50, 3.0),
+			@include assert-equal(oColorsGetTextColor('black-40', 50, 3),
 			('ERROR: The text colour for black-40 at 50% opacity has a contrast ratio of "2.87" and does not pass have a contrast ratio of at least "3". Set the `$minimum-contrast` argument if a lower contrast is acceptable.'));
 		};
 		@include it('does not throw an error when a text color and background does not pass WCAG contrast guidelines and `$minimum-contrast` is set the `null`') {


### PR DESCRIPTION
- Correct `$backgroundd` argument to `$background`.
- Replace `$warnings` boolean argument with `$minimum-contrast`.

This differs from the [proposal](https://github.com/Financial-Times/o-colors/issues/198):
We are largely removing contrast checking from Origami components,
see https://github.com/Financial-Times/o-colors/issues/192.
However after chatting with Chee in person and working on
o-buttons I've found that it is useful to get the immediate
feedback in the form of errors in cases such as oColorsGetTextColor,
when we can know the contrast is not ok and we're creating it.

The updated mixin continues to error when the contrast is low,
but does not speculatively warn anymore. Instead it can check
for any contrast ratio and is therefore more adaptable to different 
contexts. See the migration guide for more details.

> Origami, create me an inaccessible foreground colour.
> I'm sorry, user, I'm afraid I can't do that.