### PR TITLE
Update colour utility functions.

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -61,6 +61,16 @@ As `o-colors` [no longer outputs usecase CSS classes](#MIGRATION.md#migrating-fr
 ));
 ```
 
+#### oColorsGetContrastRatio
+
+The arguments of `oColorsGetContrastRatio` have been renamed. `$col1` becomes `$color-a` and `$col2` becomes `$color-b`. As well as a CSS colour, palette colour names are now also accepted.
+
+```diff
+	$contrast: oColorsGetContrastRatio('paper', 'teal');
+-	$contrast: oColorsGetContrastRatio($col1: oColorsGetPaletteColor('paper'), $col2: oColorsGetPaletteColor('teal'));
++	$contrast: oColorsGetContrastRatio($color-a: 'paper', $color-b: 'teal');
+```
+
 #### oColorsGetTextColor
 
 The name of the first argument of `oColorsGetTextColor` has changed. It was `$backgroundd` (with a double `d`) but it now spelled correctly as `$background`. E.g:

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -66,7 +66,7 @@ As `o-colors` [no longer outputs usecase CSS classes](#MIGRATION.md#migrating-fr
 The arguments of `oColorsGetContrastRatio` have been renamed. `$col1` becomes `$color-a` and `$col2` becomes `$color-b`. As well as a CSS colour, palette colour names are now also accepted.
 
 ```diff
-	$contrast: oColorsGetContrastRatio('paper', 'teal');
+	$contrast: oColorsGetContrastRatio(#ffffff, #000000);
 -	$contrast: oColorsGetContrastRatio($col1: oColorsGetPaletteColor('paper'), $col2: oColorsGetPaletteColor('teal'));
 +	$contrast: oColorsGetContrastRatio($color-a: 'paper', $color-b: 'teal');
 ```

--- a/src/scss/tools/_color.scss
+++ b/src/scss/tools/_color.scss
@@ -19,9 +19,11 @@
 
 /// Work out the brightness value in % of a color
 ///
-/// @param {Color} $color - color value to get brightness from
+/// @param {Color} $color - color value to get brightness from (either a CSS colour or o-colors palette colour name)
 /// From: https://gist.github.com/jlong/f06f5843104ee10006fe
 @function oColorsColorBrightness($color) {
+	$color: if(type-of($color) == 'string', oColorsByName($color), $color);
+
 	$red-magic-number: 241;
 	$green-magic-number: 691;
 	$blue-magic-number: 68;
@@ -42,10 +44,12 @@
 
 /// Returns the luminance of `$color` as a float (between 0 and 1)
 /// 1 is pure white, 0 is pure black
-/// @param {Color} $color - Color
+/// @param {String|Color} $color -  The colour to return a luminance for (either a CSS colour or o-colors palette colour name)
 /// @return {Number}
 /// From: https://css-tricks.com/snippets/sass/luminance-color-function/
 @function oColorsColorLuminance($color) {
+	$color: if(type-of($color) == 'string', oColorsByName($color), $color);
+
 	$colors: (
 		'red': red($color),
 		'green': green($color),
@@ -69,14 +73,14 @@
 	@return (map-get($colors, 'red') * 0.2126) + (map-get($colors, 'green') * 0.7152) + (map-get($colors, 'blue') * 0.0722);
 }
 
-/// Calculate the contrast ratio between two colors
+/// Calculate the contrast ratio between two colours.
 ///
-/// @param {Color} $col1 - first color to compare
-/// @param {Color} $col2 - second color to compare
+/// @param {String|Color} $color-a - first colour to compare (either a CSS colour or o-colors palette colour name)
+/// @param {String|Color} $color-b - second colour to compare (either a CSS colour or o-colors palette colour name)
 /// Based on the JS in https://github.com/LeaVerou/contrast-ratio/blob/gh-pages/contrast-ratio.js
-@function oColorsGetContrastRatio($col1, $col2) {
-	$l1: oColorsColorLuminance($col1) + 0.05;
-	$l2: oColorsColorLuminance($col2) + 0.05;
+@function oColorsGetContrastRatio($color-a, $color-b) {
+	$l1: oColorsColorLuminance($color-a) + 0.05;
+	$l2: oColorsColorLuminance($color-b) + 0.05;
 
 	$ratio: $l1 / $l2;
 

--- a/test/scss/tools/_color.test.scss
+++ b/test/scss/tools/_color.test.scss
@@ -1,23 +1,32 @@
 @include describe('color functions') {
 	@include describe('oColorsColorBrightness') {
 		@include test('returns the % of brightness in a color') {
-			@include assert-equal(round(oColorsColorBrightness(#ffffff)), (100%));
-			@include assert-equal(round(oColorsColorBrightness(#000000)), (0%));
-			@include assert-equal(round(oColorsColorBrightness(#fff1e5)), (96%));
+			@include assert-equal(round(oColorsColorBrightness(#ffffff)), 100%);
+			@include assert-equal(round(oColorsColorBrightness(#000000)), 0%);
+			@include assert-equal(round(oColorsColorBrightness(#fff1e5)), 96%);
+		};
+		@include test('returns the % of brightness in a palette color') {
+			@include assert-equal(round(oColorsColorBrightness('teal')), 41%);
 		};
 	};
 
 	@include describe('oColorsColorLuminance')  {
 		@include test('returns luminance of a color as float') {
-			@include assert-equal(oColorsColorLuminance(#ffffff), (1));
-			@include assert-equal(oColorsColorLuminance(#000000), (0));
+			@include assert-equal(oColorsColorLuminance(#ffffff), 1);
+			@include assert-equal(oColorsColorLuminance(#000000), 0);
+		};
+		@include test('returns luminance of a palette color as float') {
+			@include assert-equal(oColorsColorLuminance('teal'), 0.14601, $inspect: true);
 		};
 	};
 
 	@include describe('oColorsGetContrastRatio') {
 		@include test('calculate the contrast ratio between two colors') {
-			@include assert-equal(oColorsGetContrastRatio(#ffffff, #fff1e5), (1.1));
-			@include assert-equal(oColorsGetContrastRatio(#000000, #fff1e5), (18.96));
+			@include assert-equal(oColorsGetContrastRatio(#ffffff, #fff1e5), 1.1, $inspect: true);
+			@include assert-equal(oColorsGetContrastRatio(#000000, #fff1e5), 18.96, $inspect: true);
+		};
+		@include test('calculate the contrast ratio between two palette colors') {
+			@include assert-equal(oColorsGetContrastRatio('paper', 'black-10'), 1.24, $inspect: true);
 		};
 	};
 };


### PR DESCRIPTION
The following functions now accept a String of a palette colour name
as well as a Color.
- oColorsColorBrightness
- oColorsColorLuminance
- oColorsGetContrastRatio

`oColorsColorBrightness` also has updated parameters.
See the [v5 proposal](https://github.com/Financial-Times/o-colors/issues/198)
E.g.
```diff
	$contrast: oColorsGetContrastRatio(#ffffff, #000000);
-	$contrast: oColorsGetContrastRatio($col1: oColorsGetPaletteColor('paper'), $col2: oColorsGetPaletteColor('teal'));
+	$contrast: oColorsGetContrastRatio($color-a: 'paper', $color-b: 'teal');
```