### PR TITLE
Fix `oColorsGetTextColor`.

### DIFF
--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -211,7 +211,7 @@
 /// Returns a text color based on the background and
 /// an opacity percentage the color should appear at
 ///
-/// @param {Color} $background - the palette name or hex of the background the text will appear on
+/// @param {Color|String} $background - the palette name or hex of the background the text will appear on
 /// @param {Number} $opacity [100] - the opacity percentage the text color should appear at
 /// @param {String|Null} $minimum-contrast ['aa-normal'] - the minimum contrast ratio standard between the background and the returned text color, one of: aa-normal, aa-large, aaa-normal, aaa-large. See [WCAG 2.1 guidelines](https://www.w3.org/TR/WCAG21/#contrast-minimum). If the contrast ratio is too low to meet the selected guideline an error is thrown. Set to `null` to remove contrast checking and never throw an error.
 @function oColorsGetTextColor($background, $opacity: 90, $minimum-contrast: 'aa-normal') {
@@ -241,25 +241,41 @@
 		@return _error("'#{inspect($opacity)}' is not a valid opacity, set to a number.'");
 	}
 
-	// Calculate text colour for background and opacity.
-	$required-contrast-ratio: map-get($contrast-levels, $minimum-contrast);
-	$base-color: if(oColorsColorBrightness($background) > 35%, 'black', 'white');
-	$text-color: oColorsMix($base-color, $background, $opacity);
+	$contrast-ratio-aim: map-get(
+		$contrast-levels,
+		if($minimum-contrast, $minimum-contrast, 'aa-normal')
+	);
 
-	// Check text/background contrast ratio.
-	$contrast-ratio: oColorsGetContrastRatio($text-color, $background);
-	@if $minimum-contrast != null and $contrast-ratio < $required-contrast-ratio {
+	// Calculate text colour for background and opacity.
+	$base-color-a: if(oColorsColorBrightness($background) < 65%, 'white', 'black');
+	$text-color-a: oColorsMix($base-color-a, $background, $opacity);
+	$contrast-ratio-a: oColorsGetContrastRatio($text-color-a, $background);
+	@if $contrast-ratio-a > $contrast-ratio-aim {
+		@return $text-color-a;
+	}
+
+	// Switch the base colour if the first attempt did not pass contrast checks.
+	$base-color-b: if($base-color-a == 'black', 'white', 'black');
+	$text-color-b: oColorsMix($base-color-b, $background, $opacity);
+	$contrast-ratio-b: oColorsGetContrastRatio($text-color-b, $background);
+	@if $contrast-ratio-b > $contrast-ratio-aim {
+		@return $text-color-b;
+	}
+
+	// Error if neither base colour produced a text colour of high enough contrast.
+	@if $minimum-contrast != null {
+		$best-contrast-ratio: if($contrast-ratio-a > $contrast-ratio-b, $contrast-ratio-a, $contrast-ratio-b);
 		@return _error(
 			'The text colour generated for #{inspect($background-name)} at ' +
 			'#{inspect($opacity)}% opacity has a contrast ratio of ' +
-			'"#{inspect($contrast-ratio)}" and does not pass the WCAG 2.1 ' +
+			'"#{inspect($best-contrast-ratio)}" and does not pass the WCAG 2.1 ' +
 			'#{$minimum-contrast} required contrast ratio of at least ' +
-			'#{$required-contrast-ratio}:1. Update the `$minimum-contrast` argument ' +
+			'#{$contrast-ratio-aim}:1. Update the `$minimum-contrast` argument ' +
 			'if a lower contrast is acceptable.'
 		);
 	}
 
-	@return $text-color;
+	@return if($contrast-ratio-a > $contrast-ratio-b, $text-color-a, $text-color-b);
 }
 
 /// Work out the brightness value in % of a color

--- a/test/scss/_functions.test.scss
+++ b/test/scss/_functions.test.scss
@@ -102,8 +102,15 @@
 	};
 
 	@include describe('oColorsGetTextColor') {
-		@include it('returns a text color based on background and opacity percentage') {
-			@include assert-equal(oColorsGetTextColor(oColorsByName('paper')), (#1a1817));
+		@include it('returns a text color based on background colour and opacity percentage') {
+			@include assert-equal(oColorsGetTextColor(oColorsByName('paper')), #1a1817);
+			@include assert-equal(oColorsGetTextColor(oColorsByName('oxford-80'), 100), white);
+			@include assert-equal(oColorsGetTextColor(oColorsByName('oxford-90'), 100), black);
+		};
+		@include it('returns a text color based on background colour name and opacity percentage') {
+			@include assert-equal(oColorsGetTextColor('paper'), #1a1817);
+			@include assert-equal(oColorsGetTextColor('oxford-80', 100), white);
+			@include assert-equal(oColorsGetTextColor('oxford-90', 100), black);
 		};
 		@include it('throws an error if a text color and background does not pass WCAG contrast guidelines') {
 			@include assert-equal(oColorsGetTextColor('black-40', 50),


### PR DESCRIPTION
As before try both black and white base colours when generating
a text colour. Continue to prefer white as the base colour
below 65% brightness (as in the current major release).