### PR TITLE
Support setting usecases with custom colours.

### DIFF
--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -45,9 +45,11 @@
 /// @param {String|Color|Null} - The fallback if the usecase is not found. Either a colour, palette colour string, or `null` (note: the default is `false` to indicate no fallback).
 /// @return {Color} - The usecase colour.
 @function oColorsByUsecase($usecase, $property, $fallback: false, $from: 'o-colors') {
-	// Find the colour name of the requested usecase. Fallback to null so we can
-	// handle a fallback colour or colour name if no usecase is found.
-	$color: oColorsNameByUsecase($usecase, $property, $fallback: null, $from: $from);
+	// Find the colour name of the requested usecase.
+	$details: oColorsUsecaseDetails($usecase, $property, $from: $from);
+	$details: if($details, $details, ());
+	$color: map-get($details, 'color');
+	$from: map-get($details, 'from');
 	// If no usecase was found and null was given as a fallback return null.
 	@if $color == null and $fallback == null {
 		@return null;
@@ -58,20 +60,19 @@
 	}
 	// If no usecase was found and a colour name was given as a fallback find the colour from the name.
 	@if $color == null and type-of($fallback) == 'string' {
-		@return oColorsByName($fallback);
+		@return oColorsByName($fallback, $from: 'o-colors');
 	}
 
-	@return oColorsByName($color);
+	@return oColorsByName($color, $from: $from);
 }
 
-/// Return the defined palette color name for a use case / property combination
+/// Return the defined palette color name and the project it was set by for a use case / property combination
 ///
 /// @param {String} $usecase - The name of the usecase, e.g. 'page'.
 /// @param {String} $property - The usecase property e.g. 'text', 'background', 'border', 'outline'
-/// @param {Color|Null} $fallback - The value to return if the usecase isn't found.
 /// @param {String|Null} - The fallback name if the usecase is not found. Either a palette colour string or `null` (note: the default is `false` to indicate no fallback).
-/// @return {String} - The usecase colour name.
-@function oColorsNameByUsecase($usecase, $property, $fallback: false, $from: 'o-colors') {
+/// @return {Map|Null} - The usecase colour name "color" and the project it was set by "from" e.g. `('color': 'paper', 'from': 'o-colors')`. Or null if the usecase is not set.
+@function oColorsUsecaseDetails($usecase, $property, $from: 'o-colors') {
 	// Validate usecase is a string.
 	@if(type-of($usecase) != 'string') {
 		@return _error('`$usecase` should be a string but found ' +
@@ -91,35 +92,24 @@
 		'"#{inspect($valid-properties)}" but found "#{inspect($property)}".');
 	}
 
-	// Validate fallback is a colour or null.
-	// `false` is used as a default to indicate the user has not passed a fallback.
-	$valid-fallback: type-of($fallback) == 'string' or type-of($fallback) == 'null';
-	@if($fallback != false and not $valid-fallback) {
-		@return _error('`$fallback` should be a valid colour name or `null`, ' +
-		'found "#{inspect($fallback)}".');
-	}
-
-	// Get properties for usecase. Error if none are found.
+	// Return null if no usecase is found.
 	$namespaced-usecase: '#{$from}-#{$usecase}';
 	$config: map-get($_o-colors-usecases, $namespaced-usecase);
 	@if($config == null) {
-		@return if($valid-fallback, $fallback, _error(
-			'The colour usecase #{inspect($usecase)} couldn\'t be found ' +
-			'for #{inspect($from)}'
-		));
+		@return null;
 	}
 
-	// Get colour for usecase property. If none are found look for the property
-	// specifically, see if the usecase has set a colour for `all` properties.
-	// Error if no colour is found.
+	// Get colour for usecase property.
+	// If the colour was defined as a map it's a custom colour.
+	// $color: ('color': 'my-color', 'from': 'my-project')
 	$colors: map-get($config, 'colors');
-	$color: map-get($colors, $property);
-	$color: if($color, $color, map-get($colors, all));
-	@if($color == null) {
-		@return if($valid-fallback, $fallback, _error(
-			'The colour usecase property #{inspect($property)} couldn\'t ' +
-			'be found within the #{inspect($from)} #{inspect($usecase)} usecase.'
-		));
+	$color-config: map-get($colors, $property);
+	$color-name: if(type-of($color-config) == 'map', map-get($color-config, 'color'), $color-config);
+	$color-from: if(type-of($color-config) == 'map', map-get($color-config, 'from'), 'o-colors');
+
+	// Return null if no property is found.
+	@if($color-name == null) {
+		@return null;
 	}
 
 	// Output any deprecation warnings, if not already.
@@ -139,7 +129,10 @@
 		$_o-colors-deprecation-warnings-output: append($_o-colors-deprecation-warnings-output, $deprecated-key) !global;
 	}
 
-	@return $color;
+	@return (
+		'color': $color-name,
+		'from': $color-from,
+	);
 }
 
 /// Returns a brighter or darker tone of a colour, where the hue remains

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -69,6 +69,12 @@
 ///     	'border': 'black-50'
 ///     ));
 ///
+/// @example Setting a custom colour to a 'stripe' usecase with background.
+///     @include oColorsSetColor($project-name: 'o-example', $color-name: 'my-pink', $color-hex: #ff69b4);
+///     @include oColorsSetUseCase('o-example', 'stripe', (
+///     	'background': ('color': 'my-pink', 'from': 'o-example'),
+///     ));
+///
 /// @example Deprecating all usecase properties (removing a colour usecase is a breaking change).
 ///     @include oColorsSetUseCase('o-example', 'stripe', (
 ///     	'text': 'white',
@@ -98,6 +104,24 @@
 	// Error if usecase colours are not a map.
 	@if (type-of($colors) != 'map') {
 		@error '`$colors` must be a map of usecase properties (\'text\', \'background\', \'border\', or \'outline\') to colours.';
+	}
+
+	// Error if any of the usecase colours are not a string, to define a default
+	// o-colors palette colour, or a map, to define a custom palette colour.
+	@each $property, $color in $colors {
+		@if(type-of($color) != 'map' and type-of($color) != 'string') {
+			@error 'A usecase "#{$usecase}" for "#{$project-name}" ' +
+			'cannot be set with a property "#{inspect($property)}" of colour "#{inspect($color)}". ' +
+			'Colours must be a default o-colors name such as "paper" or a map to use a custom colour ' +
+			'e.g. (\'color\': \'my-color\', \'from\': \'my-project\').';
+		}
+
+		@if(type-of($color) == 'map' and not map-has-key($color, 'color') and not map-has-key($color, 'from')) {
+			@error 'A usecase "#{$usecase}" for "#{$project-name}" ' +
+			'cannot be set with a property "#{inspect($property)}" of colour "#{inspect($color)}". ' +
+			'Expected a "color" and "from" key to use a custom colour ' +
+			'e.g. (\'color\': \'my-color\', \'from\': \'my-project\').';
+		}
 	}
 
 	// Default o-colors usecases may be customised by users.

--- a/test/scss/_functions.test.scss
+++ b/test/scss/_functions.test.scss
@@ -42,17 +42,18 @@
 		};
 	};
 
-	@include describe('oColorsNameByUsecase') {
+	@include describe('oColorsUsecaseDetails') {
 		@include it('returns the palette color name for a use case') {
-			@include assert-equal(oColorsNameByUsecase(focus, outline), 'black-50');
-			@include assert-equal(oColorsNameByUsecase(page, background), 'paper');
+			@include assert-equal(oColorsUsecaseDetails(focus, outline), ('color': 'black-50', 'from': 'o-colors'));
+			@include assert-equal(oColorsUsecaseDetails(page, background), ('color': 'paper', 'from': 'o-colors'));
 		};
 
-		@include it('returns a fallback for a usecase which does not exist') {
-			@include assert-equal(oColorsNameByUsecase('fake-usecase-does-not-exist', 'text', $fallback: null), null);
-			@include assert-equal(oColorsNameByUsecase('fake-usecase-does-not-exist', 'text', $fallback: 'teal'), 'teal');
+		@include it('returns null for a usecase which does not exist') {
+			@include assert-equal(oColorsUsecaseDetails('page', 'text'), null); // text property does not exist for page
+			@include assert-equal(oColorsUsecaseDetails('fake-usecase-does-not-exist', 'text'), null);
 		};
 	};
+
 	@include describe('oColorsByUsecase') {
 		@include it('returns the palette color for a use case') {
 			@include assert-equal(oColorsByUsecase(focus, outline), oColorsByName('black-50'));

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -126,6 +126,20 @@
 			));
 			@include assert-equal(oColorsByUsecase(test-case, text), oColorsByName('candy'));
 		};
+		@include it('add a custom use case property for a custom colour') {
+			// A custom colour set by an "o-example" component.
+			$example-color: #808000;
+			@include oColorsSetColor('o-example', 'paper', $example-color);
+			// A custom usecase by an "o-example" component, using a custom colour.
+			@include oColorsSetUseCase('o-example', 'page', (
+				'background': ('color': 'paper', 'from': 'o-example')
+			));
+			// Assert able to get the new "o-example" usecase.
+			@include assert-equal(
+				oColorsByUsecase('page', 'background', $from: 'o-example'),
+				$example-color
+			);
+		};
 		@include it('override a default o-colors custom use case property') {
 			@include oColorsSetUseCase('o-colors', 'page', (
 				'background': 'candy'


### PR DESCRIPTION
As custom colours are namespaced explicitly it was not possible to
create a usecase with a custom colour.

```scss
@include oColorsSetColor(
    $project-name: 'o-share',
    $color-name: 'super-pink',
    $color-hex: #f11050
);

@include oColorsSetUseCase(
    $project-name: 'o-share',
    $usecase: 'social-icon',
    $colors: (
        'background': 'super-pink' // nope, super-pink is not in the default palette
    )
);
```

This commit updates `oColorsSetUseCase` to support this with a map:

```scss
@include oColorsSetUseCase(
    $project-name: 'o-share',
    $usecase: 'social-icon',
    $colors: (
        'background':  ('name': 'super-pink' , 'from': 'o-share')
    )
);
```

The api is unchanged for default colours:

```scss
@include oColorsSetUseCase(
    $project-name: 'o-share',
    $usecase: 'social-icon',
    $colors: (
        'background':  'teal'
    )
);
```

`oColorsNameByUsecase` has also been updated and renamed to `oColorsUsecaseDetails`.
It returns a colour name and which project it is from. `null` is returned rather than
an error so the comsumer may more easily decide what to do when usecase details aren't found.
This is simiar to `oColorsGetTone` which also returns a map. Functions which return a colour
continue to error by default (e.g. `oColorsByName`) to avoid accidentally removing a CSS property.

```scss
// would return 'super-pink'
// super-pink is not in the default palette
$color: oColorsNameByUsecase('social-icon', 'background', $from: 'o-share');
```

```scss
// returns ('color': 'super-pink', 'from': 'o-share')
$details: oColorsUsecaseDetails('social-icon', 'background', $from: 'o-share');
```