### PR TITLE
Remane `$color-hex` arguments to `$color-value`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Colour names must be namespaced for the project or component using a forward sla
 // Set a custom palette colour within a component `o-example`.
 @include oColorsSetColor(
 	$color-name: 'o-example/myhotpink',
-	$color-hex: #ff69b4
+	$color-value: #ff69b4
 );
 
 .example {
@@ -135,7 +135,7 @@ Removing a colour is considered a breaking change and requires a major release. 
 // Deprecate a custom colour, which will be removed in a future major release.
 @include oColorsSetColor(
 	$color-name: 'o-example/myhotpink',
-	$color-hex #ff69b4,
+	$color-value #ff69b4,
 	$opts: ('deprecated': 'Use the default colour claret instead.')
 );
 ```

--- a/main.scss
+++ b/main.scss
@@ -52,9 +52,9 @@
 			'muted': ('text'),
 		) {
 			.o-colors-#{$usecase}-#{$property} {
-				$color-hex: oColorsByUsecase($usecase, $property, $fallback: null);
+				$color-value: oColorsByUsecase($usecase, $property, $fallback: null);
 				$css-property: if($property == 'text', 'color', $property);
-				#{$css-property}: $color-hex;
+				#{$css-property}: $color-value;
 			}
 		}
 	}
@@ -72,9 +72,9 @@
 				'link': ('text'),
 				'link-hover': ('text'),
 			) {
-				$color-hex: oColorsByUsecase($usecase, $property, $fallback: null);
-				@if $color-hex {
-					#{--o-colors-}#{$usecase}-#{$property}: $color-hex;
+				$color-value: oColorsByUsecase($usecase, $property, $fallback: null);
+				@if $color-value {
+					#{--o-colors-}#{$usecase}-#{$property}: $color-value;
 				}
 			}
 		}

--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -168,13 +168,13 @@
 ///    $color-name: map-get($tone-details, 'color-name'); // claret
 ///    $value: map-get($tone-details, 'value'); // 80
 ///
-/// @param {String} $color - the palette colour hex or color name e.g. 'claret-80'
+/// @param {String} $color - the palette colour or color name e.g. 'claret-80'
 /// @return {Map|Null} - the details of the given tone e.g. ('color-name': 'claret', 'value': 80)					)
 @function oColorsGetToneDetails($color) {
 	$color: if(type-of($color) == 'string', oColorsByName($color), $color);
 	$hue: hue($color);
 	@each $tone-color, $tone-config in $_o-colors-default-palette-tones {
-		// Check its hex against tone to find the tone value.
+		// Check the given colour against the tone to find the tone value.
 		$value: 0;
 		@while $value <= 100 {
 			@if(inspect(oColorsGetTone($tone-color, $value)) == inspect($color)) {
@@ -214,12 +214,12 @@
 /// Returns a text color based on the background and
 /// an opacity percentage the color should appear at
 ///
-/// @param {Color|String} $background - the palette name or hex of the background the text will appear on
+/// @param {Color|String} $background - the color or palette color name of the background the text will appear on
 /// @param {Number} $opacity [100] - the opacity percentage the text color should appear at
 /// @param {String|Null} $minimum-contrast ['aa-normal'] - the minimum contrast ratio standard between the background and the returned text color, one of: aa-normal, aa-large, aaa-normal, aaa-large. See [WCAG 2.1 guidelines](https://www.w3.org/TR/WCAG21/#contrast-minimum). If the contrast ratio is too low to meet the selected guideline an error is thrown. Set to `null` to remove contrast checking and never throw an error.
 @function oColorsGetTextColor($background, $opacity: 90, $minimum-contrast: 'aa-normal') {
-	// Get background hex if palette colour name has been given.
 	$background-name: $background;
+	// Get background color if palette colour name has been given.
 	$background: if(type-of($background) == 'string', oColorsByName($background), $background);
 
 	// Contrast values. See https://www.w3.org/TR/WCAG21/#contrast-minimum
@@ -237,7 +237,7 @@
 	}
 
 	@if type-of($background) != color {
-		@return _oColorsError("'#{inspect($background)}' is not a valid color. To get a text color, please supply a valid hex code or color name for the background color'");
+		@return _oColorsError("'#{inspect($background)}' is not a valid color. To get a text color, please supply a valid color or palette color name for the background color'");
 	}
 
 	@if type-of($opacity) != 'number' {

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -1,22 +1,22 @@
 /// Define a new palette color.
 ///
 /// @example scss - Add a custom palette color
-///     @include oColorsSetColor($color-name: 'o-example/pink', $color-hex: #ff69b4);
+///     @include oColorsSetColor($color-name: 'o-example/pink', $color-value: #ff69b4);
 ///
 /// @example scss - Deprecate a set colour (removing a color from the palette is considered a breaking change and requires a major release).
-///     @include oColorsSetColor(
+///     @include oColorsSetColor (
 ///     	$color-name: 'o-example/pink',
-///     	$color-hex #ff69b4,
+///     	$color-value #ff69b4,
 ///     	$opts: (deprecated: 'your deprecation message')
 ///     );
 ///
 /// @param {String} $color-name - The name of the colour e.g. 'o-example/paper'.
-/// @param {Color} $color-hex - The colour to set (hex) e.g. #ff69b4.
+/// @param {Color} $color-value - The colour to set e.g. #ff69b4.
 /// @param {Map} $opts [()] - A map of options. Accepts a `deprecated` key with a message to deprecated a set colour e.g. `$opts: (deprecated: 'your deprecation message')`.
-@mixin oColorsSetColor($color-name, $color-hex, $opts: ()) {
-	// Validate color-hex.
-	@if type-of($color-hex) != 'color' {
-		@error 'Expected `$color-hex` to be a colour, found "#{$color-hex}" of type "#{type-of($color-hex)}".';
+@mixin oColorsSetColor($color-name, $color-value, $opts: ()) {
+	// Validate color-value.
+	@if type-of($color-value) != 'color' {
+		@error 'Expected `$color-value` to be a colour, found "#{$color-value}" of type "#{type-of($color-value)}".';
 	}
 	// Validate color-name.
 	@if type-of($color-name) != 'string' {
@@ -48,7 +48,7 @@
 	// do not have to check returned colour names with the namespace.
 	$color-name: _oColorsRemoveDefaultNamespace($color-name);
 	$new-color: ($color-name: (
-		'value': $color-hex,
+		'value': $color-value,
 		'name': $color-name,
 		'meta': ('deprecated': $deprecation-message)
 	));
@@ -184,9 +184,9 @@
 /// Add default o-colors palette colours.
 /// @access private
 @mixin _oColorsSetDefaultPaletteColors {
-	@each $color-name, $color-hex, $opts in $_o-colors-default-palette-colors {
+	@each $color-name, $color-value, $opts in $_o-colors-default-palette-colors {
 		$opts: if($opts, $opts, ());
-		@include oColorsSetColor('o-colors/#{$color-name}', $color-hex, $opts);
+		@include oColorsSetColor('o-colors/#{$color-name}', $color-value, $opts);
 	}
 }
 


### PR DESCRIPTION
A colour may be given in a non-hex format.