### PR TITLE
Restore "transparent" to the o-colors palette.

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -60,7 +60,6 @@ Removed CSS classes for palette colours:
 The following colours have been removed from the palette:
 
 - `inherit`. Replace `oColorsGetPaletteColor('inherit');` with `inherit`.
-- `transparent`. Replace `oColorsGetPaletteColor('transparent');` with `transparent`.
 
 Deprecated internal and whitelabel brand palette colours were removed. Please contact Origami if your product has a usecase for one of the removed colours:
 - Internal brand: candy, wasabi, org-b2c, org-b2c-dark, org-b2c-light, paper, wheat, sky, velvet, mandarin, claret.

--- a/src/scss/_palette.scss
+++ b/src/scss/_palette.scss
@@ -2,6 +2,7 @@
 $_o-colors-default-palette-colors: join((
 	('black', #000000),
 	('white', #ffffff),
+	('transparent', transparent),
 ), $_o-colors-default-palette-colors);
 
 // Master brand palette.

--- a/test/scss/_functions.test.scss
+++ b/test/scss/_functions.test.scss
@@ -19,6 +19,7 @@
 			@include assert-equal(oColorsByName('org-b2c'), (#4e96eb));
 			@include assert-equal(oColorsByName('org-b2c-dark'), (#3a70af));
 			@include assert-equal(oColorsByName('org-b2c-light'), (#99c6fb));
+			@include assert-equal(oColorsByName('transparent'), (transparent));
 		};
 		@include it('returns an error if `$color-name` is not a string') {
 			@include assert-equal(oColorsByName(null),
@@ -35,6 +36,7 @@
 			@include assert-equal(oColorsMix($percentage: 20), (#ccc1b7));
 			@include assert-equal(oColorsMix($color: 'claret', $background: 'wheat', $percentage: 50), (#c67786));
 			@include assert-equal(oColorsMix('claret', 'wheat', 50), (#c67786));
+			@include assert-equal(oColorsMix('black', 'transparent', 50), rgba(0, 0, 0, 0.5));
 		};
 	};
 


### PR DESCRIPTION
It is a valid colour.