### PR TITLE
Usecase hexes

### DIFF
--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -41,27 +41,61 @@
 /// @return {Color} - The usecase colour.
 @function oColorsByUsecase($usecase, $property, $fallback: false) {
 	// Find the colour name of the requested usecase.
-	$details: oColorsUsecaseDetails($usecase, $property);
-	$details: if($details, $details, ());
-	$color-name: map-get($details, 'color-name');
+	// Validate usecase is a string.
+	@if(type-of($usecase) != 'string') {
+		@return _oColorsError('`$usecase` should be a string but found ' +
+		'"#{inspect($usecase)}" of type "#{type-of($usecase)}".');
+	}
+
+	// Validate property is allowed.
+	$valid-properties: ('text', 'background', 'border', 'outline');
+	@if(not index($valid-properties, $property)) {
+		@return _oColorsError('`$property` should be one of ' +
+		'"#{inspect($valid-properties)}" but found "#{inspect($property)}".');
+	}
+
+	// Find usecase config.
+	$config: map-get($_o-colors-usecases, $usecase);
+	$config: if($config, $config, ());
+
+	// Get colour for usecase property.
+	$colors: if($config, map-get($config, 'colors'), null);
+	$color: if($colors, map-get($colors, $property), null);
+
+	// Output any deprecation warnings, if not already.
+	$opts: if($config, map-get($config, 'opts'), ());
+	$deprecated: if(type-of($opts) == 'map', map-get($opts, 'deprecated'), null);
+	$deprecated-key: 'usecase-#{$usecase}-#{$property}';
+	@if(not index($_o-colors-deprecation-warnings-output, $deprecated-key)) {
+		@if (type-of($deprecated) == 'string') {
+			@warn 'Color usecase "#{inspect($usecase)}" is deprecated ' +
+			'(property "#{inspect($property)}" was requested): #{inspect($deprecated)}';
+		}
+		@if (type-of($deprecated) == 'map' and map-has-key($deprecated, $property)) {
+			@warn 'The "#{inspect($property)}" property of the "#{inspect($usecase)}" ' +
+			'color usecase is deprecated. #{inspect(map-get($deprecated, $property))}';
+		}
+		$_o-colors-deprecation-warnings-output: append($_o-colors-deprecation-warnings-output, $deprecated-key) !global;
+	}
+
 	// If no usecase was found and null was given as a fallback return null.
-	@if $color-name == null and $fallback == null {
+	@if $color == null and $fallback == null {
 		@return null;
 	}
 	// If no usecase was found and a colour was given as a fallback return the fallback.
-	@if $color-name == null and type-of($fallback) == 'color' {
+	@if $color == null and type-of($fallback) == 'color' {
 		@return $fallback;
 	}
 	// If no usecase was found and a string was given as a fallback return the fallback color.
-	@if $color-name == null and type-of($fallback) == 'string' {
+	@if $color == null and type-of($fallback) == 'string' {
 		@return oColorsByName($fallback);
 	}
 	// Error if no colour is found.
-	@if($color-name == null) {
+	@if($color == null) {
 		@return _oColorsError('Could not find a colour for the "#{$usecase}" "#{$property}" usecase.');
 	}
 
-	@return oColorsByName($color-name);
+	@return if(type-of($color) == 'string', oColorsByName($color), $color);
 }
 
 /// Return usecase information such as its palette color name.

--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -98,61 +98,6 @@
 	@return if(type-of($color) == 'string', oColorsByName($color), $color);
 }
 
-/// Return usecase information such as its palette color name.
-///
-/// @param {String} $usecase - The name of the usecase, e.g. 'page'.
-/// @param {String} $property - The usecase property e.g. 'text', 'background', 'border', 'outline'
-/// @return {Map|Null} - The usecase colour name "color-name" e.g. `('color-name': 'paper')`. Or null if the usecase is not set.
-@function oColorsUsecaseDetails($usecase, $property) {
-	// Validate usecase is a string.
-	@if(type-of($usecase) != 'string') {
-		@return _oColorsError('`$usecase` should be a string but found ' +
-		'"#{inspect($usecase)}" of type "#{type-of($usecase)}".');
-	}
-
-	// Validate property is allowed.
-	$valid-properties: ('text', 'background', 'border', 'outline');
-	@if(not index($valid-properties, $property)) {
-		@return _oColorsError('`$property` should be one of ' +
-		'"#{inspect($valid-properties)}" but found "#{inspect($property)}".');
-	}
-
-	// Return null if no usecase is found.
-	$config: map-get($_o-colors-usecases, $usecase);
-	@if($config == null) {
-		@return null;
-	}
-
-	// Get colour for usecase property.
-	$colors: map-get($config, 'colors');
-	$color-name: map-get($colors, $property);
-
-	// Return null if no property is found.
-	@if($color-name == null) {
-		@return null;
-	}
-
-	// Output any deprecation warnings, if not already.
-	$opts: map-get($config, 'opts');
-	$deprecated: if(type-of($opts) == 'map', map-get($opts, 'deprecated'), null);
-	$deprecated-key: 'usecase-#{$usecase}-#{$property}';
-	@if(not index($_o-colors-deprecation-warnings-output, $deprecated-key)) {
-		@if (type-of($deprecated) == 'string') {
-			@warn 'Color usecase "#{inspect($usecase)}" is deprecated ' +
-			'(property "#{inspect($property)}" was requested): #{inspect($deprecated)}';
-		}
-		@if (type-of($deprecated) == 'map' and map-has-key($deprecated, $property)) {
-			@warn 'The "#{inspect($property)}" property of the "#{inspect($usecase)}" ' +
-			'color usecase is deprecated. #{inspect(map-get($deprecated, $property))}';
-		}
-		$_o-colors-deprecation-warnings-output: append($_o-colors-deprecation-warnings-output, $deprecated-key) !global;
-	}
-
-	@return (
-		'color-name': $color-name
-	);
-}
-
 /// Returns a brighter or darker tone of a colour, where the hue remains
 /// the same but the saturation and luminance changes.
 ///

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -108,12 +108,12 @@
 			@error 'A property "#{inspect($property)}" cannot be set for usecase "#{$usecase}".' +
 			'A property may be one of "#{$valid-properties}".';
 		}
-		@if(type-of($color) != 'string') {
+		@if(type-of($color) != 'string' and type-of($color) != 'color') {
 			@error 'The "#{$usecase}" usecase property "#{inspect($property)}" ' +
 			'cannot be set to "#{inspect($color)}". A usecase property may ' +
-			'only be set to an o-colors colour name such as "paper".';
+			'only be set to an o-colors colour or colour name such as "paper".';
 		}
-		@if(not _oColorsNameExists($color)) {
+		@if(type-of($color) == 'string' and not _oColorsNameExists($color)) {
 			@error 'The "#{$usecase}" usecase property "#{inspect($property)}" ' +
 			'cannot be set to "#{inspect($color)}". The colour "#{inspect($color)}" ' +
 			'does not exist.';

--- a/test/scss/_functions.test.scss
+++ b/test/scss/_functions.test.scss
@@ -40,37 +40,6 @@
 		};
 	};
 
-	@include describe('oColorsUsecaseDetails') {
-		@include it('returns the palette color name for a usecase') {
-			@include assert-equal(oColorsUsecaseDetails(focus, outline), ('color-name': 'black-50'));
-			@include assert-equal(oColorsUsecaseDetails(page, background), ('color-name': 'paper'));
-		};
-
-		@include it('returns null for a usecase which does not exist') {
-			@include assert-equal(oColorsUsecaseDetails('page', 'text'), null); // text property does not exist for page
-			@include assert-equal(oColorsUsecaseDetails('fake-usecase-does-not-exist', 'text'), null);
-		};
-
-		@include it('returns the palette color name for a custom usecase') {
-			// A custom usecase by an "o-example" component
-			@include oColorsSetUseCase('o-example/page-1', (
-				'background': 'paper'
-			));
-			@include assert-equal(oColorsUsecaseDetails('o-example/page-1', 'background'), ('color-name': 'paper'));
-		};
-
-		@include it('returns the palette color name for a custom usecase using a custom colour') {
-			// A custom colour set by an "o-example" component.
-			$example-color: #808000;
-			@include oColorsSetColor('o-example/paper-2', $example-color);
-			// A custom usecase by an "o-example" component, using a custom colour.
-			@include oColorsSetUseCase('o-example/page-2', (
-				'background': 'o-example/paper-2'
-			));
-			@include assert-equal(oColorsUsecaseDetails('o-example/page-2', 'background'), ('color-name': 'o-example/paper-2'));
-		};
-	};
-
 	@include describe('oColorsByUsecase') {
 		@include it('returns the palette color for a use case') {
 			@include assert-equal(oColorsByUsecase(focus, outline), oColorsByName('black-50'));

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -140,6 +140,14 @@
 				$example-color
 			);
 		};
+		@include it('add a custom use case property for a colour mix') {
+			$mix: oColorsMix('teal', 'slate', 50);
+			@include oColorsSetUseCase('o-example/mix', (
+				 'background': $mix
+			));
+			// Assert able to get the new "o-example" mix usecase.
+			@include assert-equal(oColorsByUsecase('o-example/mix', 'background'), $mix);
+		};
 		@include it('override a default o-colors custom use case property') {
 			@include oColorsSetUseCase('o-colors/page', (
 				'background': 'candy'


### PR DESCRIPTION
**Allow hex values as colour usecases.**
This enables a usecase to be set to an o-colors mix.

**Remove `oColorsUsecaseDetails`.**
This is only used by the o-buttons beta and is no longer required,
as buttons may now be generated using a hex colour as well as a
colour name. We can remove this.