### PR TITLE
Restore wheat tones.

### DIFF
--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -138,7 +138,7 @@
 	$has-tone-config: map-has-key($_o-colors-tone-saturation, $color-name);
 	@if (not $has-tone-config and ($color-name == 'white' or $color-name == 'black')) {
 		@return _oColorsError('"#{$color-name}" does not support tones. ' +
-			'Consider using a mix instead e.g: ' +
+			'Use a mix instead: ' +
 			'`oColorsMix(\'#{$color-name}\', $percentage: #{$brightness})`');
 	}
 	@if (not $has-tone-config) {

--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -131,18 +131,20 @@
 @function oColorsGetTone($color-name, $brightness) {
 	$color: oColorsByName($color-name);
 	$hue: hue($color);
-	// Find a tone from a base of 90% saturation.
-	// The reason for this is not known. It's here to preserve the tones we
-	// currently have. The base starting used to be configured per colour
-	// and may once have differed from colour to colour.
-	$saturation: 90;
+	// Find a tone from a base of saturation which differs per colour.
+	$saturation: map-get($_o-colors-tone-saturation, $color-name);
 
 	// Validate the given colour allows different tones.
-	$has-tone-config: map-has-key($_o-colors-default-palette-tones, $color-name);
-	@if (not $has-tone-config) {
+	$has-tone-config: map-has-key($_o-colors-tone-saturation, $color-name);
+	@if (not $has-tone-config and ($color-name == 'white' or $color-name == 'black')) {
 		@return _oColorsError('"#{$color-name}" does not support tones. ' +
 			'Consider using a mix instead e.g: ' +
 			'`oColorsMix(\'#{$color-name}\', $percentage: #{$brightness})`');
+	}
+	@if (not $has-tone-config) {
+		@return _oColorsError('"#{$color-name}" does not support tones. ' +
+			'Consider using the `oColorsMix` function to mix with black to ' +
+			'darken or mix with white to lighten.');
 	}
 
 	// Validate brightness.

--- a/src/scss/_palette.scss
+++ b/src/scss/_palette.scss
@@ -59,7 +59,7 @@ $_o-colors-default-palette-colors: join((
 	$_o-colors-default-palette-tones: map-merge((
 		'claret': (30, 40, 50, 60, 70, 80, 90, 100),
 		'oxford': (30, 40, 50, 60, 70, 80, 90, 100),
-		'teal': (20, 30, 40, 50, 60, 70, 80, 90, 100),
+		'teal': (20, 30, 40, 50, 60, 70, 80, 90, 100)
 	), $_o-colors-default-palette-tones);
 }
 

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -12,6 +12,14 @@ $o-colors-is-silent: true !default;
 /// @access private
 $_o-colors-default-palette-colors: () !default;
 
+/// A map of colours which allow tones to their base tone saturation.
+$_o-colors-tone-saturation: (
+    'claret': 90,
+    'oxford': 90,
+    'teal': 90,
+    'wheat': 15
+);
+
 /// A map to define default tones in the palette.
 /// This is also used to decide which colours are
 /// allowed to have tones, when users request a

--- a/test/scss/_functions.test.scss
+++ b/test/scss/_functions.test.scss
@@ -116,10 +116,10 @@
 
 		@include it('returns an error for palette colours which do not allow tones') {
 			@include assert-equal(oColorsGetTone('black', 10),
-			('ERROR: "black" does not support tones. Use a mix instead e.g: `oColorsMix(\'black\', $percentage: 10)`'),
+			('ERROR: "black" does not support tones. Use a mix instead: `oColorsMix(\'black\', $percentage: 10)`'),
 			 $inspect: true);
 			@include assert-equal(oColorsGetTone('white', 10),
-			('ERROR: "white" does not support tones. Use a mix instead e.g: `oColorsMix(\'white\', $percentage: 10)`'),
+			('ERROR: "white" does not support tones. Use a mix instead: `oColorsMix(\'white\', $percentage: 10)`'),
 			 $inspect: true);
 			@include assert-equal(oColorsGetTone('slate', 10),
 			('ERROR: "slate" does not support tones. Consider using the `oColorsMix` function to mix with black to darken or mix with white to lighten.'),

--- a/test/scss/_functions.test.scss
+++ b/test/scss/_functions.test.scss
@@ -111,11 +111,18 @@
 	@include describe('oColorsGetTone') {
 		@include it('returns a tone for palette colours that allow tones') {
 			@include assert-equal(oColorsGetTone('claret', 30), #4d081f, $inspect: true);
+			@include assert-equal(oColorsGetTone('wheat', 100), #ffebd9, $inspect: true);
 		};
 
 		@include it('returns an error for palette colours which do not allow tones') {
-			@include assert-equal(oColorsGetTone('paper', 10),
-			('ERROR: "paper" does not support tones. Consider using a mix instead e.g: `oColorsMix(\'paper\', $percentage: 10)`'),
+			@include assert-equal(oColorsGetTone('black', 10),
+			('ERROR: "black" does not support tones. Use a mix instead e.g: `oColorsMix(\'black\', $percentage: 10)`'),
+			 $inspect: true);
+			@include assert-equal(oColorsGetTone('white', 10),
+			('ERROR: "white" does not support tones. Use a mix instead e.g: `oColorsMix(\'white\', $percentage: 10)`'),
+			 $inspect: true);
+			@include assert-equal(oColorsGetTone('slate', 10),
+			('ERROR: "slate" does not support tones. Consider using the `oColorsMix` function to mix with black to darken or mix with white to lighten.'),
 			 $inspect: true);
 		};
 	};


### PR DESCRIPTION
A wheat tone is used in article pages, so allow wheat to be toned
again.