### PR TITLE
Allow custom colours to be set twice, if the value is unchanged.

### DIFF
--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -37,12 +37,16 @@
 	// colours usually happens at a component level.
 	$color-exists: _oColorsNameExists($color-name);
 	@if ($namespace != 'o-colors' and $color-exists) {
-		@error 'A palette colour "#{$color-name}" has already been set. ' +
-		'Only default o-colors palette colours may be overridden with `oColorsSetColor`. ' +
-		'If you would like to customise "#{$namespace}" colours, check its README for ' +
-		'customisation options, or contact the Origami team to propose new customisation features.';
+		$existing-current-color: oColorsByName($color-name);
+		// The colour may be set twice by the same component if it's included twice.
+		// So only error if it's being set again with a new colour.
+		@if ($existing-current-color != $color-value) {
+			@error 'A palette colour "#{$color-name}" has already been set. ' +
+			'Only default o-colors palette colours may be overridden with `oColorsSetColor`. ' +
+			'If you would like to customise "#{$namespace}" colours, check its README for ' +
+			'customisation options, or contact the Origami team to propose new customisation features.';
+		}
 	}
-
 	// Set the new colour to the colour palette.
 	// Set colours without the default o-colors namespace so consumers
 	// do not have to check returned colour names with the namespace.
@@ -131,10 +135,15 @@
 		$colors: map-merge($current-colors, $colors);
 	}
 
+	$new-usecase-config: (
+		$usecase: ('colors': $colors, 'opts': $opts)
+	);
+
 	// Existing project/component usecases may not be customised by users:
 	// Customisation for non-default usecases usually happens on the component
 	// level, with component specific mixins.
-	@if ($namespace != 'o-colors' and map-has-key($_o-colors-usecases, $usecase)) {
+	$current-usecase-config: map-get($_o-colors-usecases, $usecase);
+	@if ($namespace != 'o-colors' and $current-usecase-config and $current-usecase-config != $new-usecase-config) {
 		@error 'A usecase "#{$usecase}" has already been set. ' +
 		'Only default o-colors usecases may be overridden with `oColorsSetUseCase`. ' +
 		'If you would like to customise "#{$namespace}" colours, check its README for ' +
@@ -142,9 +151,7 @@
 	}
 
 	// Add the use-case and its properties to the global use-case map.
-	$_o-colors-usecases: map-merge($_o-colors-usecases, (
-		$usecase: ('colors': $colors, 'opts': $opts)
-	)) !global;
+	$_o-colors-usecases: map-merge($_o-colors-usecases, $new-usecase-config) !global;
 }
 
 /// Update the palette with default tones.

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -117,6 +117,12 @@
 			// reset paper color
 			@include oColorsSetColor('o-colors/paper', #fff1e5);
 		};
+		@include it('set a custom color twice with the same value') {
+			// if a component is imported twice it may attempt
+			// to set a colour twice
+			@include oColorsSetColor('o-demo-twice/paper', hotpink);
+			@include oColorsSetColor('o-demo-twice/paper', hotpink);
+		};
 	};
 
 	@include describe('oColorSetUseCase') {
@@ -149,6 +155,17 @@
 			@include assert-equal(oColorsByUsecase('o-example/mix', 'background'), $mix);
 		};
 		@include it('override a default o-colors custom use case property') {
+			@include oColorsSetUseCase('o-colors/page', (
+				'background': 'candy'
+			));
+			@include assert-equal(oColorsByUsecase('page', 'background'), oColorsByName('candy'));
+		};
+		@include it('set a usecase twice with the same value') {
+			// if a component is imported twice it may attempt
+			// to set a usecase twice
+			@include oColorsSetUseCase('o-colors/page', (
+				'background': 'candy'
+			));
 			@include oColorsSetUseCase('o-colors/page', (
 				'background': 'candy'
 			));


### PR DESCRIPTION
We do not allow custom colours to be overriden. However, components may be
included by a project's dependencies multiple times. This means custom colours
may be set multiple times by the same component. So, only error if a custom
colour is set with a _different_ value.

https://github.com/Financial-Times/o-colors/issues/237