### PR TITLE
Allow custom colour usecases to be set twice, if the value is unchanged.

### DIFF
--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -135,9 +135,7 @@
 		$colors: map-merge($current-colors, $colors);
 	}
 
-	$new-usecase-config: (
-		$usecase: ('colors': $colors, 'opts': $opts)
-	);
+	$new-usecase-config: ('colors': $colors, 'opts': $opts);
 
 	// Existing project/component usecases may not be customised by users:
 	// Customisation for non-default usecases usually happens on the component
@@ -151,7 +149,9 @@
 	}
 
 	// Add the use-case and its properties to the global use-case map.
-	$_o-colors-usecases: map-merge($_o-colors-usecases, $new-usecase-config) !global;
+	$_o-colors-usecases: map-merge($_o-colors-usecases, (
+		#{$usecase}: $new-usecase-config
+	)) !global;
 }
 
 /// Update the palette with default tones.

--- a/test/scss/_mixins.test.scss
+++ b/test/scss/_mixins.test.scss
@@ -163,13 +163,13 @@
 		@include it('set a usecase twice with the same value') {
 			// if a component is imported twice it may attempt
 			// to set a usecase twice
-			@include oColorsSetUseCase('o-colors/page', (
+			@include oColorsSetUseCase('o-example/page-set-twice', (
 				'background': 'candy'
 			));
-			@include oColorsSetUseCase('o-colors/page', (
+			@include oColorsSetUseCase('o-example/page-set-twice', (
 				'background': 'candy'
 			));
-			@include assert-equal(oColorsByUsecase('page', 'background'), oColorsByName('candy'));
+			@include assert-equal(oColorsByUsecase('o-example/page-set-twice', 'background'), oColorsByName('candy'));
 		};
 	};
 };


### PR DESCRIPTION
Builds on and fixes: 630ef07654045ffe6a05e5a0be47cdc5f2a75337
Relates to: https://github.com/Financial-Times/o-colors/issues/237

Context:
We do not allow custom colour usecases to be overriden. However, components
may be included by a project's dependencies multiple times. This means custom
colours may be set multiple times by the same component. So, only error if a
custom colour is set with a _different_ value.