### PR TITLE
Fix whitelabel demos.

### DIFF
--- a/demos/src/contrast-checker/fieldsets/mixer.mustache
+++ b/demos/src/contrast-checker/fieldsets/mixer.mustache
@@ -73,6 +73,6 @@
 		<label title="100%">
 			<input type=radio form="color-selectors" name="range" value="{{name}}">
 		</label>
-		<button class="o-buttons o-buttons--mono o-overlay__close" id="add-mix">Add</button>
+		<button class="o-buttons o-buttons--secondary o-buttons--mono o-overlay__close" id="add-mix">Add</button>
 	</fieldset>
 </script>

--- a/origami.json
+++ b/origami.json
@@ -19,13 +19,8 @@
 		"sass": "demos/src/demo.scss",
 		"js": "demos/src/demo.js",
 		"dependencies": [
-			"o-buttons@^6.0.0",
 			"o-fonts@^4.0.0",
-			"o-forms@^8.0.0",
-			"o-normalise@^2.0.0",
-			"o-overlay@^3.0.0",
-			"o-syntax-highlight@^3.0.0",
-			"o-tabs@^5.0.0"
+			"o-normalise@^2.0.0"
 		]
 	},
 	"ci": {
@@ -40,6 +35,15 @@
 			"sass": "demos/src/contrast-checker/contrast-checker.scss",
 			"template": "demos/src/contrast-checker/index.mustache",
 			"display_html": false,
+			"dependencies": [
+				"o-buttons@^6.0.0",
+				"o-fonts@^4.0.0",
+				"o-forms@^8.0.0",
+				"o-normalise@^2.0.0",
+				"o-overlay@^3.0.0",
+				"o-syntax-highlight@^3.0.0",
+				"o-tabs@^5.0.0"
+			],
 			"brands": [
 				"master"
 			]
@@ -52,6 +56,13 @@
 			"sass": "demos/src/color-mixer/color-mixer.scss",
 			"template": "demos/src/color-mixer/index.mustache",
 			"display_html": false,
+			"dependencies": [
+				"o-fonts@^4.0.0",
+				"o-forms@^8.0.0",
+				"o-normalise@^2.0.0",
+				"o-overlay@^3.0.0",
+				"o-syntax-highlight@^3.0.0"
+			],
 			"brands":	[
 				"master"
 			]
@@ -119,6 +130,15 @@
 			"sass": "demos/src/contrast-checker/contrast-checker.scss",
 			"template": "demos/src/contrast-checker/index.mustache",
 			"display_html": false,
+			"dependencies": [
+				"o-buttons@^6.0.0",
+				"o-fonts@^4.0.0",
+				"o-forms@^8.0.0",
+				"o-normalise@^2.0.0",
+				"o-overlay@^3.0.0",
+				"o-syntax-highlight@^3.0.0",
+				"o-tabs@^5.0.0"
+			],
 			"brands": [
 				"internal"
 			]
@@ -131,6 +151,13 @@
 			"sass": "demos/src/color-mixer/color-mixer.scss",
 			"template": "demos/src/color-mixer/index.mustache",
 			"display_html": false,
+			"dependencies": [
+				"o-fonts@^4.0.0",
+				"o-forms@^8.0.0",
+				"o-normalise@^2.0.0",
+				"o-overlay@^3.0.0",
+				"o-syntax-highlight@^3.0.0"
+			],
 			"brands":	[
 				"internal"
 			]


### PR DESCRIPTION
`o-syntax-highlight` does not support the whitelabel brand. It
cannot be included as a dependency to whitelabel brand demos.

Fixes: https://github.com/Financial-Times/o-colors/issues/236