### PR TITLE
Add Mandarin to the internal brand

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,13 +85,13 @@ teal | master, internal
 slate | master, internal,
 lemon | master, internal,
 jade | master, internal
+mandarin | master, internal
 crimson | master, internal
 paper | master
 claret | master
 wheat | master
 sky | master
 velvet | master
-mandarin | master
 candy | master
 wasabi | master
 org-b2c | master

--- a/demos/src/palettes/internal-palette.json
+++ b/demos/src/palettes/internal-palette.json
@@ -13,6 +13,7 @@
 	],
 	"tertiary": [
 		{ "name": "jade" },
+		{ "name": "mandarin" },
 		{ "name": "crimson" }
 	],
 	"tones": [


### PR DESCRIPTION
Mandarin is now used in three different places that we know of:
- SOS for amber rating labels and as a mid-point between green and red
- o-meter
- Biz-Ops (work being done to add an amber label now)

I think we should make it available. I've added it to tertiary colors so
it appears next to jade and crimson, does that make sense?

Resolves #245.