### PR TITLE
Allow custom colour tones

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,15 +117,32 @@ To set a custom palette colour to share with other components call `oColorsSetCo
 Colour names must be namespaced for the project or component using a forward slash.
 
 ```scss
-// Set a custom palette colour within a component `o-example`.
+// Set a custom palette colour within a project `o-example`.
 @include oColorsSetColor(
 	$color-name: 'o-example/myhotpink',
 	$color-value: #ff69b4
 );
 
 .example {
-	// Get a custom palette colour from a component `o-example`.
+	// Get a custom palette colour from a project `o-example`.
 	background: oColorsByName('o-example/myhotpink');
+}
+```
+
+By default custom colours do not allow [tones](#tone-palette-colors) to reduce the number of colours used within a project. To allow tones set the `allow-tones` option.
+
+```scss
+// Set a custom palette colour within a project `o-example`,
+// which allows tones of the same colour.
+@include oColorsSetColor(
+	$color-name: 'o-example/myhotpink',
+	$color-value: #ff69b4,
+	$opts: ('allow-tones': true)
+);
+
+.example {
+	// Get a toned custom palette colour from a project `o-example`.
+	background-color: oColorsGetTone('o-example/myhotpink', 80);
 }
 ```
 
@@ -292,7 +309,7 @@ Recommended tones are already in the colour palette, e.g. `teal-80` (see [defaul
 }
 ```
 
-For design consistency not all colours are allowed to be toned. Only colours with default tones in the palette (e.g. teal, oxford, and claret) may be used. Other colours [may still be mixed](#mix-colors).
+For design consistency not all colours are allowed to be toned. Only colours with default tones in the palette (e.g. teal, oxford, and claret) may be used. Other colours [may still be mixed](#mix-colors). If your project has defined custom colours using `oColorsSetColor`, these may be toned by setting the [`allow-tones` option](#custom-palette-colours).
 
 #### Colour Tools
 

--- a/demos/src/color-mixer/color-mixer.scss
+++ b/demos/src/color-mixer/color-mixer.scss
@@ -1,7 +1,7 @@
 $o-colors-is-silent: false;
 
 // Import colors module
-@import '../../../main';
+@import './../../main';
 
 :root {
 	--color: #000000;
@@ -49,7 +49,7 @@ input[type=radio] { //sass-lint:disable-line no-qualifying-elements
 	height: 35px;
 	width: 100px;
 	vertical-align: middle;
-	
+
 	&:hover {
 		cursor: pointer;
 		outline: 2px solid var(--color);

--- a/demos/src/contrast-checker/contrast-checker.scss
+++ b/demos/src/contrast-checker/contrast-checker.scss
@@ -1,7 +1,7 @@
 $o-colors-is-silent: false;
 
 // Import colors module
-@import '../../../main';
+@import './../../main';
 
 @mixin swatchStyle() {
 	appearance: none;

--- a/origami.json
+++ b/origami.json
@@ -118,7 +118,7 @@
 			"title": "Tones and Mixes",
 			"data": "demos/src/palettes/master-palette.json",
 			"template": "demos/src/tones-mixes.mustache",
-			"description": "Tones (colours with modified saturation and lightness) can be used to produce a broad spectrum of lighter and darker variations of palette colours for creating scale and depth to your designs. To reduce our number of colour combinations not all colours may be toned, but mixes of black/white may be used instead.",
+			"description": "Tones (colours with modified brightness using the HSB colour space) can be used to produce a broad spectrum of lighter and darker variations of palette colours for creating scale and depth to your designs. To reduce our number of colour combinations not all colours may be toned, but mixes of black/white may be used instead.",
 			"display_html": false,
 			"brands": [
 				"master"
@@ -204,7 +204,7 @@
 			"title": "Tones and Mixes",
 			"data": "demos/src/palettes/internal-palette.json",
 			"template": "demos/src/tones-mixes.mustache",
-			"description": "Tones (colours with modified saturation and lightness) can be used to produce a broad spectrum of lighter and darker variations of palette colours for creating scale and depth to your designs. To reduce our number of colour combinations not all colours may be toned, but mixes of black/white may be used instead.",
+			"description": "Tones (colours with modified brightness using the HSB colour space) can be used to produce a broad spectrum of lighter and darker variations of palette colours for creating scale and depth to your designs. To reduce our number of colour combinations not all colours may be toned, but mixes of black/white may be used instead.",
 			"display_html": false,
 			"brands": [
 				"internal"
@@ -226,7 +226,7 @@
 			"title": "Tones and Mixes",
 			"data": "demos/src/palettes/whitelabel-palette.json",
 			"template": "demos/src/tones-mixes.mustache",
-			"description": "Tones (colours with modified saturation and lightness) can be used to produce a broad spectrum of lighter and darker variations of palette colours for creating scale and depth to your designs. To reduce our number of colour combinations not all colours may be toned, but mixes of black/white may be used instead.",
+			"description": "Tones (colours with modified brightness using the HSB colour space) can be used to produce a broad spectrum of lighter and darker variations of palette colours for creating scale and depth to your designs. To reduce our number of colour combinations not all colours may be toned, but mixes of black/white may be used instead.",
 			"display_html": false,
 			"brands": [
 				"whitelabel"

--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -432,14 +432,14 @@
 /// @param {Color} $hex - The hex colour value to find hsb values for.
 /// @return {Map} - map of `h`, `s`, `b` colour values.
 @function _oColorsHexToHsbValues($hex) {
-	$r: red($hex);
-	$g: green($hex);
-	$b: blue($hex);
+	$redValue: red($hex);
+	$greenValue: green($hex);
+	$blueValue: blue($hex);
 
 	// Find smallest and largest amount of colour.
 	$min: null;
 	$max: null;
-	@each $var in ($r, $g, $b) {
+	@each $var in ($redValue, $greenValue, $blueValue) {
 		@if $min == null or $var < $min {
 			$min: $var;
 		}
@@ -452,9 +452,9 @@
 	// Difference between the smallest and largest amount of colour.
 	$delta: $max - $min;
 
-	$h: hue($hex);
-	$s: if($max == 0, 0, $delta / $max);
-	$b: $max / 255;
+	$hue: hue($hex);
+	$saturation: if($max == 0, 0, $delta / $max);
+	$brightness: $max / 255;
 
-    @return ('h': $h, 's': $s * 100, 'b': $b * 100);
+    @return ('h': $hue, 's': $saturation * 100, 'b': $brightness * 100);
 }

--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -426,6 +426,8 @@
 ///
 /// Logic derived from chroma.js
 /// https://github.com/gka/chroma.js/blob/088e18f50a3b5b1d009ce68f540265cafa0cb6a1/src/io/hsv/rgb2hsv.js#L10
+/// HSL to HSB is also documented here, if you prefer math:
+/// https://www.rapidtables.com/convert/color/rgb-to-hsv.html
 ///
 /// @access private
 ///

--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -108,37 +108,42 @@
 /// @param {String} $color-name - the name of the color to be shaded
 /// @param {Number} $brightness - the brightness value of the new color, 0-100
 @function oColorsGetTone($color-name, $brightness) {
+	// Find palette colour information.
 	$color: oColorsByName($color-name);
-	$hue: hue($color);
-	// Find a tone from a base of saturation which differs per colour.
-	$saturation: map-get($_o-colors-tone-saturation, $color-name);
-
-	// Validate the given colour allows different tones.
-	$has-tone-config: map-has-key($_o-colors-tone-saturation, $color-name);
-	@if (not $has-tone-config and ($color-name == 'white' or $color-name == 'black')) {
-		@return _oColorsError('"#{$color-name}" does not support tones. ' +
-			'Use a mix instead: ' +
-			'`oColorsMix(\'#{$color-name}\', $percentage: #{$brightness})`');
-	}
-	@if (not $has-tone-config) {
-		@return _oColorsError('"#{$color-name}" does not support tones. ' +
-			'Consider using the `oColorsMix` function to mix with black to ' +
-			'darken or mix with white to lighten.');
-	}
+	$color-map: map-get($_o-colors-palette, $color-name);
+	$color-meta: map-get($color-map, 'meta');
 
 	// Validate brightness.
 	@if(type-of($brightness) != 'number' or $brightness > 100 or $brightness < 0) {
 		@return _oColorsError('"$brightness" must be a number between 0 and 100.');
 	}
 
-	@if $brightness == 0 {
-		@return hsla(0, 0, 0, 1);
-	} @else {
-		$hsl-luminance: ($brightness/2) * (2 - ($saturation/100));
-		$hsl-saturation: ($brightness * $saturation) / if($hsl-luminance < 50, $hsl-luminance * 2, 200 - $hsl-luminance * 2);
-
-		@return hsla($hue, $hsl-saturation, $hsl-luminance, 1);
+	// Error for white and black colours which have no hue, they cannot be toned.
+	@if (hue($color) == 0) {
+		@return _oColorsError('"#{$color-name}" does not support tones. ' +
+			'Use a mix instead: ' +
+			'`oColorsMix(\'#{$color-name}\', $percentage: #{$brightness})`');
 	}
+
+	// Error for any palette colour which hasn't been configured to allow tones.
+	$allows-tones: map-get($color-meta, 'allow-tones');
+	@if (not $allows-tones) {
+		@return _oColorsError('"#{$color-name}" does not allow tones. ' +
+			'We only allow tones for some colours, to reduce the number ' +
+			'of different colours used across sites. ' +
+			'For custom colours, set the `allow-tones` option ' +
+			'of `oColorsSetColor` to enable tones. ' +
+			'If using a default o-colors colour consider using the `oColorsMix` ' +
+			'function to mix with black to darken or white to lighten.');
+	}
+
+	// Convert the given colour to the HSB colour space.
+	$hsb: _oColorsHexToHsbValues($color);
+	$hsb-hue: map-get($hsb, 'h');
+	$hsb-saturation: map-get($hsb, 's');
+	// Update the colours brightness with the given brightness value,
+	// using the HSB colour space.
+	@return _oColorsHsbToHex($hsb-hue, $hsb-saturation, $brightness);
 }
 
 /// Figure out if a given colour is a tone. If it is a tone return the original
@@ -396,4 +401,60 @@
 /// Check if a colour name exists in the palette.
 @function _oColorsNameExists($color-name) {
 	@return map-has-key($_o-colors-palette, $color-name);
+}
+
+/// Converts HSB/HSV values to a hex colour
+///
+/// @access private
+///
+/// @param {Number} $hue - number between 0-360
+/// @param {Number} $saturation - number between 0-100
+/// @param {Number} $brigthness - number between 0-100
+///
+/// @return {Colour} - the hex representation of given hsb values
+@function _oColorsHsbToHex($hue, $saturation, $brightness) {
+	@if $brightness == 0 {
+		@return hsl(0, 0, 0);
+	}
+
+	$hsl-luminance: ($brightness/2) * (2 - ($saturation/100));
+	$hsl-saturation: ($brightness * $saturation) / if($hsl-luminance < 50, $hsl-luminance * 2, 200 - $hsl-luminance * 2);
+	@return hsl($hue, $hsl-saturation, $hsl-luminance);
+}
+
+/// Returns HSB/HSV colour values for a given colour hex.
+///
+/// Logic derived from chroma.js
+/// https://github.com/gka/chroma.js/blob/088e18f50a3b5b1d009ce68f540265cafa0cb6a1/src/io/hsv/rgb2hsv.js#L10
+///
+/// @access private
+///
+/// @param {Color} $hex - The hex colour value to find hsb values for.
+/// @return {Map} - map of `h`, `s`, `b` colour values.
+@function _oColorsHexToHsbValues($hex) {
+	$r: red($hex);
+	$g: green($hex);
+	$b: blue($hex);
+
+	// Find smallest and largest amount of colour.
+	$min: null;
+	$max: null;
+	@each $var in ($r, $g, $b) {
+		@if $min == null or $var < $min {
+			$min: $var;
+		}
+
+		@if $max == null or $var > $max {
+			$max: $var;
+		}
+	}
+
+	// Difference between the smallest and largest amount of colour.
+	$delta: $max - $min;
+
+	$h: hue($hex);
+	$s: if($max == 0, 0, $delta / $max);
+	$b: $max / 255;
+
+    @return ('h': $h, 's': $s * 100, 'b': $b * 100);
 }

--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -118,7 +118,7 @@
 		@return _oColorsError('"$brightness" must be a number between 0 and 100.');
 	}
 
-	// Error for white and black colours which have no hue, they cannot be toned.
+	// Error for colours which have no hue, such as white and black, which we do not allow tones of.
 	@if (hue($color) == 0) {
 		@return _oColorsError('"#{$color-name}" does not support tones. ' +
 			'Use a mix instead: ' +

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -7,7 +7,10 @@
 ///     @include oColorsSetColor (
 ///     	$color-name: 'o-example/pink',
 ///     	$color-value #ff69b4,
-///     	$opts: (deprecated: 'your deprecation message')
+///     	$opts: (
+///     		'allow-tones': true,
+///     		'deprecated': 'your deprecation message'
+///     	)
 ///     );
 ///
 /// @param {String} $color-name - The name of the colour e.g. 'o-example/paper'.
@@ -32,6 +35,9 @@
 	// Get deprecation message.
 	$deprecation-message: map-get($opts, 'deprecated');
 
+	// Get tones option.
+	$allow-tones: map-get($opts, 'allow-tones');
+
 	// Default o-colors palette colours may be customised by users but
 	// existing project/component colors may not. Customisation of non-default
 	// colours usually happens at a component level.
@@ -54,7 +60,10 @@
 	$new-color: ($color-name: (
 		'value': $color-value,
 		'name': $color-name,
-		'meta': ('deprecated': $deprecation-message)
+		'meta': (
+			'deprecated': $deprecation-message,
+			'allow-tones': if($allow-tones == true, true, false)
+		)
 	));
 	$_o-colors-palette: map-merge($_o-colors-palette, $new-color) !global;
 };

--- a/src/scss/_palette.scss
+++ b/src/scss/_palette.scss
@@ -1,3 +1,5 @@
+
+
 // Define universal primary palette.
 $_o-colors-default-palette-colors: join((
 	('black', #000000),
@@ -10,12 +12,12 @@ $_o-colors-default-palette-colors: join((
 	$_o-colors-default-palette-colors: join((
 		// primary palette
 		('paper', #fff1e5),
-		('claret', #990f3d),
-		('oxford', #0f5499),
-		('teal', #0d7680),
+		('claret', #990f3d, ('allow-tones': true)),
+		('oxford', #0f5499, ('allow-tones': true)),
+		('teal', #0d7680, ('allow-tones': true)),
 
 		//secondary palette
-		('wheat', #f2dfce),
+		('wheat', #f2dfce, ('allow-tones': true)),
 		('sky', #cce6ff),
 		('slate', #262a33),
 		('velvet', #593380),
@@ -39,8 +41,8 @@ $_o-colors-default-palette-colors: join((
 @if oBrandGetCurrentBrand() == internal {
 	$_o-colors-default-palette-colors: join((
 		// primary palette
-		('oxford', #0f5499),
-		('teal', #0d7680),
+		('oxford', #0f5499, ('allow-tones': true)),
+		('teal', #0d7680, ('allow-tones': true)),
 
 		//secondary palette
 		('lemon', #ffec1a),

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -17,14 +17,6 @@ $_o-colors-is-initialised: false !default;
 /// @access private
 $_o-colors-default-palette-colors: () !default;
 
-/// A map of colours which allow tones to their base tone saturation.
-$_o-colors-tone-saturation: (
-    'claret': 90,
-    'oxford': 90,
-    'teal': 90,
-    'wheat': 15
-);
-
 /// A map to define default tones in the palette.
 /// This is also used to decide which colours are
 /// allowed to have tones, when users request a

--- a/test/scss/_functions.test.scss
+++ b/test/scss/_functions.test.scss
@@ -78,12 +78,26 @@
 	};
 
 	@include describe('oColorsGetTone') {
-		@include it('returns a tone for palette colours that allow tones') {
+		@include it('returns a tone for default palette colours that allow tones') {
+			@include assert-equal(oColorsGetTone('claret', 30), #4d081f, $inspect: true);
 			@include assert-equal(oColorsGetTone('claret', 30), #4d081f, $inspect: true);
 			@include assert-equal(oColorsGetTone('wheat', 100), #ffebd9, $inspect: true);
 		};
 
-		@include it('returns an error for palette colours which do not allow tones') {
+		@include it('returns a tone for custom palette colours that allow tones') {
+			@include oColorsSetColor(
+				'o-example/olive-with-tones-allowed',
+				#808000,
+				('allow-tones': true)
+			);
+			@include assert-equal(
+				oColorsGetTone('o-example/olive-with-tones-allowed', 100),
+				yellow,
+				$inspect: true
+			);
+		};
+
+		@include it('returns an error for default palette colours which do not allow tones') {
 			@include assert-equal(oColorsGetTone('black', 10),
 			('ERROR: "black" does not support tones. Use a mix instead: `oColorsMix(\'black\', $percentage: 10)`'),
 			 $inspect: true);
@@ -91,7 +105,17 @@
 			('ERROR: "white" does not support tones. Use a mix instead: `oColorsMix(\'white\', $percentage: 10)`'),
 			 $inspect: true);
 			@include assert-equal(oColorsGetTone('slate', 10),
-			('ERROR: "slate" does not support tones. Consider using the `oColorsMix` function to mix with black to darken or mix with white to lighten.'),
+			('ERROR: "slate" does not allow tones. We only allow tones for some colours, to reduce the number of different colours used across sites. For custom colours, set the `allow-tones` option of `oColorsSetColor` to enable tones. If using a default o-colors colour consider using the `oColorsMix` function to mix with black to darken or white to lighten.'),
+			 $inspect: true);
+		};
+
+		@include it('returns an error for default palette colours which do not allow tones') {
+			@include oColorsSetColor(
+				'o-example/olive-without-tones',
+				#808000
+			);
+			@include assert-equal(oColorsGetTone('o-example/olive-without-tones', 100),
+			('ERROR: "o-example/olive-without-tones" does not allow tones. We only allow tones for some colours, to reduce the number of different colours used across sites. For custom colours, set the `allow-tones` option of `oColorsSetColor` to enable tones. If using a default o-colors colour consider using the `oColorsMix` function to mix with black to darken or white to lighten.'),
 			 $inspect: true);
 		};
 	};


### PR DESCRIPTION
By default colours do not allow tones to reduce the number of colours
used within a project. To allow tones of custom colours
`oColorsSetColor` has a new option `allow-tones`.

```scss
// Set a custom palette colour within a project `o-example`,
// which allows tones of the same colour.
@include oColorsSetColor(
	$color-name: 'o-example/myhotpink',
	$color-value: #ff69b4,
	$opts: ('allow-tones': true)
);

.example {
	// Get a toned custom palette colour from a project `o-example`.
	background-color: oColorsGetTone('o-example/myhotpink', 80);
}
```

Our tones work by modifying the brightness value of our palette
colours in the HSB colour space.

The previous major, v4, included a separate function to return a
hex value for given HSB values (hue, saturation, and brightness).

When calculating tones we would use the given tone value as the
HSB brightness, whilst the HSB saturation and hue was configured 
elsewhere in the codebase for each of our colours that allow tones.

v4 o-colors HSB function for reference:
https://github.com/Financial-Times/o-colors/blob/4b82f494361266d93b650134e1e5d6b012d0a170/src/scss/_mixins.scss#L121

v4 colour palette HSB saturation configuration:
https://github.com/Financial-Times/o-colors/blob/v4.10.3/src/scss/_palette.scss#L146

When working on the v5 major we didn't connect the dots and
configured the HSB saturation as a "each colour has a different
saturation starting point for some reason" ¯\_(ツ)_/¯
https://github.com/Financial-Times/o-colors/blob/ab4c18416bb77da1c07308e01f98059c4fa9c0c8/src/scss/_functions.scss#L113

To support tones of custom colours our users would have
to provide the HSB saturation when setting a custom colour.
Instead, this commit calculates the HSB saturation and removes
the configuration. It also separates out the HSB function
from the tone function again for code clarity.

The only public change here is a new option to `oColorsSetColor`.