### PR TITLE
Correct demo Sass import paths.

### DIFF
--- a/demos/src/color-mixer/color-mixer.scss
+++ b/demos/src/color-mixer/color-mixer.scss
@@ -1,7 +1,7 @@
 $o-colors-is-silent: false;
 
 // Import colors module
-@import '../../main';
+@import '../../../main';
 
 :root {
 	--color: #000000;

--- a/demos/src/contrast-checker/contrast-checker.scss
+++ b/demos/src/contrast-checker/contrast-checker.scss
@@ -1,7 +1,7 @@
 $o-colors-is-silent: false;
 
 // Import colors module
-@import '../../main';
+@import '../../../main';
 
 @mixin swatchStyle() {
 	appearance: none;


### PR DESCRIPTION
These were incorrect due to a bug in origami-build-tools.
https://github.com/Financial-Times/origami-build-tools/pull/734