### PR TITLE
add extension to relative imports to make the code work directly in a browser

### DIFF
--- a/demos/src/color-mixer/color-mixer.js
+++ b/demos/src/color-mixer/color-mixer.js
@@ -1,5 +1,5 @@
-import { getContrastRatio } from '../shared/contrast-ratio';
-import { getHexValues, mixHexes } from '../shared/colors-mix';
+import { getContrastRatio } from '../shared/contrast-ratio.js';
+import { getHexValues, mixHexes } from '../shared/colors-mix.js';
 
 document.addEventListener('o.DOMContentLoaded', function() {
 	const forms = document.forms;

--- a/demos/src/contrast-checker/contrast-checker.js
+++ b/demos/src/contrast-checker/contrast-checker.js
@@ -1,5 +1,5 @@
-import { getContrastRatio, getWCAGRating } from '../shared/contrast-ratio';
-import { getHexValues, mixHexes } from '../shared/colors-mix';
+import { getContrastRatio, getWCAGRating } from '../shared/contrast-ratio.js';
+import { getHexValues, mixHexes } from '../shared/colors-mix.js';
 
 document.addEventListener('o.DOMContentLoaded', () => {
 	const form = document.forms[0];


### PR DESCRIPTION
relative imports require the full path including the extension because browsers use the import name to make a network request and they do not implicitly add a .js file extension if one is missing