### PR TITLE
ensure the saturation and luminence values are percentages to stop deprecation warnings from being emitted

### DIFF
--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -411,12 +411,12 @@
 /// @return {Colour} - the hex representation of given hsb values
 @function _oColorsHsbToHex($hue, $saturation, $brightness) {
 	@if $brightness == 0 {
-		@return hsl(0, 0, 0);
+		@return hsl(0, 0%, 0%);
 	}
 
 	$hsl-luminance: ($brightness/2) * (2 - ($saturation/100));
 	$hsl-saturation: ($brightness * $saturation) / if($hsl-luminance < 50, $hsl-luminance * 2, 200 - $hsl-luminance * 2);
-	@return hsl($hue, $hsl-saturation, $hsl-luminance);
+	@return hsl($hue, $hsl-saturation * 1%, $hsl-luminance * 1%);
 }
 
 /// Returns HSB/HSV colour values for a given colour hex.


### PR DESCRIPTION
sass 1.32 deprecated the behaviour of allowing unitless values for saturation and luminence:
>Deprecate passing non-% numbers as lightness and saturation to hsl(), hsla(), color.adjust(), and color.change(). This matches the CSS specification, which also requires % for all lightness and saturation parameters.
> https://github.com/sass/dart-sass/releases/tag/1.32.0

This change makes our saturation and luminence values always be percentages, which is the correct type to use.