### PR TITLE
Add matisse to the master brand's tertiary palette.

### DIFF
--- a/demos/src/palettes/master-palette.json
+++ b/demos/src/palettes/master-palette.json
@@ -19,7 +19,8 @@
 		{ "name": "jade" },
 		{ "name": "wasabi" },
 		{ "name": "crimson" },
-		{ "name": "candy" }
+		{ "name": "candy" },
+		{ "name": "matisse" }
 	],
 	"b2c": [
 		{ "name": "org-b2c" },

--- a/src/scss/_palette.scss
+++ b/src/scss/_palette.scss
@@ -29,12 +29,13 @@ $_o-colors-default-palette-colors: join((
 		('wasabi', #96cc28),
 		('jade', #00994d),
 		('crimson', #cc0000),
+		('matisse', #355778),
 
 		//b2c palette
 		('org-b2c', #4e96eb),
 		('org-b2c-dark', #3a70af),
 		('org-b2c-light', #99c6fb),
-		
+
 		//brand palette
 		('brand-ft-pink', #fcd0b1),
 	), $_o-colors-default-palette-colors);


### PR DESCRIPTION
This is used to indicate partner content (aka paid/promoted content)

Requested by FT Creative, in use in production, ~**awaiting Customer Products design ops approval**~ Josh and Leonardo approve.

<img width="562" alt="Screenshot 2021-05-18 at 16 16 39" src="https://user-images.githubusercontent.com/10405691/118678146-ad294b80-b7f4-11eb-862d-fb649fbb9c98.png">
