### PR TITLE
Move matisse under a new "partner content" palette

### DIFF
--- a/demos/src/palettes/master-palette.json
+++ b/demos/src/palettes/master-palette.json
@@ -19,13 +19,15 @@
 		{ "name": "jade" },
 		{ "name": "wasabi" },
 		{ "name": "crimson" },
-		{ "name": "candy" },
-		{ "name": "matisse" }
+		{ "name": "candy" }
 	],
 	"b2c": [
 		{ "name": "org-b2c" },
 		{ "name": "org-b2c-dark" },
 		{ "name": "org-b2c-light" }
+	],
+	"partner-content": [
+		{ "name": "matisse" }
 	],
 	"brand": [
 		{ "name": "brand-ft-pink" }

--- a/demos/src/partner-content-palette.mustache
+++ b/demos/src/partner-content-palette.mustache
@@ -1,0 +1,10 @@
+<div class="demo-wrapper">
+	{{#partner-content}}
+		<div class="demo-color">
+			<h4 class="o-colors-border-{{name}}">{{name}}</h4>
+			<div class="swatch o-colors-demo-{{name}}" data-o-color="{{name}}">
+				<input type="text" class="hex" id="o-color-input-{{name}}" value="" readonly>
+			</div>
+		</div>
+	{{/partner-content}}
+</div>

--- a/origami.json
+++ b/origami.json
@@ -111,6 +111,17 @@
 			]
 		},
 		{
+			"name": "master-partner-content-palette",
+			"title": "Partner Content Palette",
+			"data": "demos/src/palettes/master-palette.json",
+			"template": "demos/src/partner-content-palette.mustache",
+			"description": "",
+			"display_html": false,
+			"brands": [
+				"master"
+			]
+		},
+		{
 			"name": "master-brand-palette",
 			"title": "Brand Palette",
 			"data": "demos/src/palettes/master-palette.json",

--- a/src/scss/_palette.scss
+++ b/src/scss/_palette.scss
@@ -29,12 +29,14 @@ $_o-colors-default-palette-colors: join((
 		('wasabi', #96cc28),
 		('jade', #00994d),
 		('crimson', #cc0000),
-		('matisse', #355778),
 
 		//b2c palette
 		('org-b2c', #4e96eb),
 		('org-b2c-dark', #3a70af),
 		('org-b2c-light', #99c6fb),
+
+		//partner content palette
+		('matisse', #355778),
 
 		//brand palette
 		('brand-ft-pink', #fcd0b1),


### PR DESCRIPTION
From FT Creative:
> The new partner content colour ‘Matisse’ is not part of the FT brand colour
> palette - it’s entirely new colour created for Partner Content and
> deliberately different from the FT’s brand colours whilst complementing them.
> Therefore, if you are going to add this to Origami, could I suggest this is
> clearly separate from our Brand secondary/tertiary palette and labelled so in
> the index (similar to eg B2C blues which has its own section)?

The design UI Kit is being updated too