### PR TITLE
expand the given hex colours to their full representation

### DIFF
--- a/demos/src/shared/colors-mix.js
+++ b/demos/src/shared/colors-mix.js
@@ -6,6 +6,18 @@ const getHexValues = (mixer, base) => {
 	};
 };
 
+const expandHexValues = (value) => {
+	// The three-digit notation (#RGB) is a shorter version of the six-digit form (#RRGGBB).
+	// For example, #f09 is the same color as #ff0099.
+	// Likewise, the four-digit RGB notation (#RGBA) is a shorter version of the eight-digit form (#RRGGBBAA).
+	if (value.length === 3 || value.length === 4) {
+		return value.split('').map(character => {
+			return character + character;
+		}).join('');
+	}
+	return value;
+};
+
 const mixHexes = (mixer, base) => {
 	const radix = 16;
 	const decimalToHex = decimal => decimal.toString(radix);
@@ -18,8 +30,8 @@ const mixHexes = (mixer, base) => {
 		let hexValue = "#";
 
 		for (let i = 0; i <= 5; i += 2) {
-			const mixPair = hexToDecimal(mixer.substr(i, 2)); // extract r, g, b pairs for mixer color
-			const basePair = hexToDecimal(base.substr(i, 2)); // extract r, g, b pairs for base color
+			const mixPair = expandHexValues(hexToDecimal(mixer.substr(i, 2))); // extract r, g, b pairs for mixer color
+			const basePair = expandHexValues(hexToDecimal(base.substr(i, 2))); // extract r, g, b pairs for base color
 
 			// combine the r/g/b pairs from each color, based on percentage
 			let combinedPair = decimalToHex(Math.round(basePair + (mixPair - basePair) * (percent / 100.0)));


### PR DESCRIPTION
The code in mixHexes assumes that the given hex colours will always be in their fully expanded form but this is not true.
This commit changes the mixHexes implementation to turn the given hex colours into their full form.

This fixes a bug where if mixHexes was given a hex colour such as fff then it would return NaN