### PR TITLE
Always use a full hex string for the constract checker and colour mixer demos

### DIFF
--- a/demos/src/contrast-checker/contrast-checker.js
+++ b/demos/src/contrast-checker/contrast-checker.js
@@ -1,5 +1,5 @@
 import { getContrastRatio, getWCAGRating } from '../shared/contrast-ratio.js';
-import { getHexValues, mixHexes } from '../shared/colors-mix.js';
+import { getHexValues, mixHexes, expandHexValues } from '../shared/colors-mix.js';
 
 document.addEventListener('DOMContentLoaded', () => {
 	const form = document.forms[0];
@@ -17,8 +17,8 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 function showContrastRatio(text, background) {
-	const textHex = changeColor(text.value, 'foreground');
-	const backgroundHex = changeColor(background.value, 'background');
+	const textHex = expandHexValues(changeColor(text.value, 'foreground'));
+	const backgroundHex = expandHexValues(changeColor(background.value, 'background'));
 
 	const ratio = getContrastRatio(textHex, backgroundHex);
 	const rating = getWCAGRating(ratio, text.value, background.value);
@@ -42,7 +42,7 @@ function changeColor(colorName, property) {
 	if (hexValue.length <= 0) { hexValue = colorName; }
 
 	root.style.setProperty(`--${property}`, hexValue);
-	return hexValue;
+	return hexValue.replace('#', '').trim();
 }
 
 let eventsAdded = false;

--- a/demos/src/shared/colors-mix.js
+++ b/demos/src/shared/colors-mix.js
@@ -19,6 +19,8 @@ const expandHexValues = (value) => {
 };
 
 const mixHexes = (mixer, base) => {
+	const fullMixer = expandHexValues(mixer);
+	const fullBase = expandHexValues(base);
 	const radix = 16;
 	const decimalToHex = decimal => decimal.toString(radix);
 	const hexToDecimal = hex => parseInt(hex, radix);
@@ -30,8 +32,8 @@ const mixHexes = (mixer, base) => {
 		let hexValue = "#";
 
 		for (let i = 0; i <= 5; i += 2) {
-			const mixPair = hexToDecimal(expandHexValues(mixer.substr(i, 2))); // extract r, g, b pairs for mixer color
-			const basePair = hexToDecimal(expandHexValues(base.substr(i, 2))); // extract r, g, b pairs for base color
+			const mixPair = hexToDecimal(fullMixer.substr(i, 2)); // extract r, g, b pairs for mixer color
+			const basePair = hexToDecimal(fullBase.substr(i, 2)); // extract r, g, b pairs for base color
 
 			// combine the r/g/b pairs from each color, based on percentage
 			let combinedPair = decimalToHex(Math.round(basePair + (mixPair - basePair) * (percent / 100.0)));
@@ -47,5 +49,6 @@ const mixHexes = (mixer, base) => {
 
 export {
 	getHexValues,
-	mixHexes
+	mixHexes,
+	expandHexValues
 };


### PR DESCRIPTION
To verify this locally you will need to modify obt to use compressed css output by changing the default value from `'expanded'` to `'compressed'` -- https://github.com/Financial-Times/origami-build-tools/blob/caddb606d50e7558809d3e79c24182d0d367e3d9/lib/tasks/build-sass.js#L80

![screenshot of contrast checker working](https://user-images.githubusercontent.com/1569131/128741100-2397fafe-9477-4be5-814c-865a0dd12066.png)

![screenshot of colour mixer working](https://user-images.githubusercontent.com/1569131/128741131-e6006e5f-06e7-483a-89f4-52fdabf09ebe.png)
