### PR TITLE
Remove brand-ft-pink

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ candy | master
 wasabi | master
 light-blue | master
 graphics-dark-blue | master
-ft-pink (previously brand-ft-pink) | master
+ft-pink | master
 ft-grey | master
 org-b2c | master
 org-b2c-dark | master

--- a/src/scss/_palette.scss
+++ b/src/scss/_palette.scss
@@ -1,5 +1,3 @@
-
-
 // Define universal primary palette.
 $_o-colors-default-palette-colors: join((
 	('transparent', transparent),
@@ -12,7 +10,6 @@ $_o-colors-default-palette-colors: join((
 		('black', #000000),
 		('white', #ffffff),
 		('ft-pink', #fcd0b1),
-		('brand-ft-pink', #fcd0b1, ('deprecated': 'Replace "brand-ft-pink" with "ft-pink". This is so we can align our naming with our designers, including the Brand team.')),
 		('ft-grey', #333333),
 
 		//secondary palette


### PR DESCRIPTION
Can merge this into the next major.

For the migration guide:

Replace any references to `brand-ft-pink` with `ft-pink`. `brand-ft-pink` was deprecated in `o-colors` version `6.1.0` and has now been completely removed.

(which will close #318 )